### PR TITLE
Changes for kibo/loa database load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Mac OSX
+.DS_Store

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,11 +2,19 @@
 Change Log
 ==========
 
-1.3.0 (unreleaded)
+1.4.0 (unreleaded)
 ------------------
 
 *Planned*: Support loading ongoing daily reductions, in particular, updates
 to tiles already in the database.
+
+1.3.0 (2024-12-09)
+------------------
+
+* This release corresponds to loading the ``loa`` spectroscopic production
+  in preparation for DR2 (PR `#17`_).
+
+.. _`#17`: https://github.com/desihub/specprod-db/pull/17
 
 1.2.1 (2024-10-07)
 ------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -43,10 +43,10 @@ extensions = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
-    'matplotlib': ('https://matplotlib.org/stable/', None),
+    # 'scipy': ('https://docs.scipy.org/doc/scipy/', None),
+    # 'matplotlib': ('https://matplotlib.org/stable/', None),
     'astropy': ('https://docs.astropy.org/en/stable/', None),
-    'h5py': ('https://docs.h5py.org/en/latest/', None),
+    # 'h5py': ('https://docs.h5py.org/en/latest/', None),
     'sqlalchemy': ('https://docs.sqlalchemy.org/en/20/', None),
     'desispec': ('https://desispec.readthedocs.io/en/latest/', None),
     'desiutil': ('https://desiutil.readthedocs.io/en/latest/', None),

--- a/doc/nb/TestNewTile.ipynb
+++ b/doc/nb/TestNewTile.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Test Load Daily\n",
     "\n",
-    "Start by loading one \"new\" tile.\n",
+    "Test various aspects of tile-based loading.\n",
     "\n",
     "## Imports"
    ]
@@ -49,27 +49,9 @@
    },
    "outputs": [],
    "source": [
-    "specprod = os.environ['SPECPROD']\n",
-    "# tile_id, tile_survey, tile_program = 3867, 'main', 'dark'\n",
-    "# tile_id, tile_survey, tile_program = 5053, 'main', 'dark'\n",
-    "# tile_id, tile_survey, tile_program = 5052, 'main', 'dark'\n",
-    "# tile_id, tile_survey, tile_program = 5074, 'main', 'dark'\n",
-    "# tile_id, tile_survey, tile_program = 1685, 'main', 'dark'\n",
-    "# tile_id, tile_survey, tile_program = 40069, 'main', 'backup'\n",
-    "# tile_id, tile_survey, tile_program = 80950, 'sv1', 'backup'\n",
-    "tile_id = 80615\n",
-    "overwrite = False\n",
-    "tiles_patch_date = '20240906'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "32c1722a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "specprod"
+    "specprod = os.environ['SPECPROD'] = 'daily'\n",
+    "overwrite = True\n",
+    "tiles_patch_date = '20241007'"
    ]
   },
   {
@@ -87,12 +69,23 @@
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:load.py:1508:setup_db: Begin creating tables.\n",
+      "INFO:load.py:1511:setup_db: Finished creating tables.\n",
+      "INFO:load.py:1411:load_versions: Loading version metadata.\n",
+      "INFO:load.py:1422:load_versions: Completed loading version metadata.\n"
+     ]
+    }
+   ],
    "source": [
     "os.environ['DESI_LOGLEVEL'] = 'DEBUG'\n",
     "db.log = get_logger(DEBUG)\n",
-    "# hostname = 'db-loadbalancer.bweaver.development.svc.spin.nersc.org'\n",
-    "hostname = 'localhost'\n",
+    "hostname = 'db2-loadbalancer.specprod.production.svc.spin.nersc.org'\n",
+    "# hostname = 'localhost'\n",
     "postgresql = db.setup_db(schema=specprod, hostname=hostname, username='desi_admin', overwrite=overwrite)\n",
     "if overwrite:\n",
     "    db.load_versions('computed', 'daily/v0', 'daily', specprod, 'main')"
@@ -108,39 +101,82 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 16,
    "id": "065e77f2-cd38-4bf7-b9c1-319bc7707dd1",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:meta.py:346:findfile: hpixdir = 'hpix'\n",
+      "DEBUG:meta.py:361:findfile: specprod_dir = '/global/cfs/cdirs/desi/spectro/redux/daily', specprod = 'None'\n",
+      "DEBUG:meta.py:375:findfile: Setting specprod = 'daily'\n",
+      "DEBUG:meta.py:32:get_desi_root_readonly: Using cached _desi_root_readonly=/dvs_ro/cfs/cdirs/desi\n"
+     ]
+    }
+   ],
    "source": [
-    "# tiles_file = findfile('tiles', readonly=True).replace('.fits', '.csv')\n",
-    "tiles_file = os.path.join(os.environ['DESI_ROOT'], 'users', os.environ['USER'], f'tiles-daily-patched-with-jura-{tiles_patch_date}.csv')\n",
-    "tiles_table = Table.read(tiles_file, format='ascii.csv')\n",
+    "original_tiles_file = os.path.join(os.environ['DESI_ROOT'], 'users', os.environ['USER'], f'tiles-daily-patched-with-kibo-{tiles_patch_date}.csv')\n",
+    "current_tiles_file = findfile('tiles', readonly=True)\n",
+    "tiles_table = Table.read(original_tiles_file, format='ascii.csv')\n",
     "# tiles_table"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "35d5c59d-920b-4625-b1a7-c81d33f97512",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/dvs_ro/cfs/cdirs/desi/spectro/redux/daily/tiles-daily.csv'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "current_tiles_file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "id": "5322bcbd-8fcf-46a1-96be-2de812f7ea08",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "row_index = np.where((tiles_table['LASTNIGHT'] >= 20201214) & (tiles_table['EFFTIME_SPEC'] > 0) & (tiles_table['TILEID'] == tile_id))[0]"
+    "row_index = np.where((tiles_table['LASTNIGHT'] >= 20201214) & (tiles_table['EFFTIME_SPEC'] > 0))[0]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "0e3c5449-449d-4474-b570-7db3aa50d87d",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 696 ms, sys: 11.9 ms, total: 707 ms\n",
+      "Wall time: 706 ms\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "candidate_tiles = db.Tile.convert(tiles_table, row_index=row_index)"
@@ -158,28 +194,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "86c45810-11c1-4010-b429-1480f9d34008",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:meta.py:346:findfile: hpixdir = 'hpix'\n",
+      "DEBUG:meta.py:361:findfile: specprod_dir = '/global/cfs/cdirs/desi/spectro/redux/daily', specprod = 'None'\n",
+      "DEBUG:meta.py:375:findfile: Setting specprod = 'daily'\n",
+      "DEBUG:meta.py:32:get_desi_root_readonly: Using cached _desi_root_readonly=/dvs_ro/cfs/cdirs/desi\n"
+     ]
+    }
+   ],
    "source": [
-    "# exposures_file = findfile('exposures', readonly=True)\n",
-    "exposures_file = os.path.join(os.environ['DESI_ROOT'], 'users', os.environ['USER'], f'exposures-daily-patched-with-jura-{tiles_patch_date}.fits')\n",
-    "exposures_table = Table.read(exposures_file, format='fits', hdu='EXPOSURES')\n",
-    "frames_table = Table.read(exposures_file, format='fits', hdu='FRAMES')\n",
+    "original_exposures_file = os.path.join(os.environ['DESI_ROOT'], 'users', os.environ['USER'], f'exposures-daily-patched-with-kibo-{tiles_patch_date}.fits')\n",
+    "current_exposures_file = findfile('exposures', readonly=True)\n",
+    "exposures_table = Table.read(original_exposures_file, format='fits', hdu='EXPOSURES')\n",
+    "frames_table = Table.read(original_exposures_file, format='fits', hdu='FRAMES')\n",
     "# exposures_table[exposures_table['TILEID'] == new_tile.tileid]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "a8517a3d-0708-4b77-80b9-cab25554580b",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 30.6 s, sys: 206 ms, total: 30.8 s\n",
+      "Wall time: 30.9 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "load_tiles = list()\n",
@@ -190,14 +246,6 @@
     "    if len(row_index) > 0:\n",
     "        load_tiles.append(new_tile)\n",
     "        load_exposures += db.Exposure.convert(exposures_table, row_index=row_index)\n",
-    "        # if (exposures_table[row_index]['MJD'] < 50000).any():\n",
-    "        #     print(\"WARNING: Invalid MJD values detected for tile {0:d}!\".format(new_tile.tileid))\n",
-    "        #     bad_index = np.where((exposures_table['TILEID'] == new_tile.tileid) & (exposures_table['EFFTIME_SPEC'] > 0) & (exposures_table['MJD'] < 50000))[0]\n",
-    "        #     for row in exposures_table[['EXPID', 'NIGHT', 'MJD', 'EFFTIME_SPEC']][bad_index]:\n",
-    "        #         raw_data_file = os.path.join(os.environ['DESI_SPECTRO_DATA'], \"{0:08d}\".format(row['NIGHT']), \"{0:08d}\".format(row['EXPID']), \"desi-{0:08d}.fits.fz\".format(row['EXPID']))\n",
-    "        #         with fits.open(raw_data_file, mode='readonly') as hdulist:\n",
-    "        #             mjd_obs = hdulist['SPEC'].header['MJD-OBS']\n",
-    "        #             print(\"WARNING: tile {0:d} exposure {1:d} has MJD-OBS = {2:f} in {3}!\".format(new_tile.tileid, row['EXPID'], mjd_obs, raw_data_file))\n",
     "    else:\n",
     "        print(\"ERROR: No valid exposures found for tile {0:d}, even though EFFTIME_SPEC == {1:f}!\".format(new_tile.tileid, new_tile.efftime_spec))\n",
     "        bad_index = np.where((exposures_table['TILEID'] == new_tile.tileid))[0]\n",
@@ -208,12 +256,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "38e20e0f-58e1-417d-b0ae-e902ac717888",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 3min 17s, sys: 1.13 s, total: 3min 18s\n",
+      "Wall time: 3min 18s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "load_frames = list()\n",
@@ -226,12 +283,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "8a509cfa-801c-4933-b550-b69ad75c337a",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2.7 s, sys: 128 ms, total: 2.83 s\n",
+      "Wall time: 3.52 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "try:\n",
@@ -244,12 +310,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "269a600d-2346-4300-b71d-a6aa4053b0d9",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 3.66 s, sys: 104 ms, total: 3.77 s\n",
+      "Wall time: 7.39 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "try:\n",
@@ -262,12 +337,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "98306e39-48fd-41bc-9161-cbe1e47c28b6",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 47.3 s, sys: 972 ms, total: 48.2 s\n",
+      "Wall time: 1min 13s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "try:\n",
@@ -276,6 +360,473 @@
     "except IntegrityError as exc:\n",
     "    print(exc.args[0])\n",
     "    db.dbSession.rollback()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c298201-3348-4e3c-8493-5b118cd3dfbc",
+   "metadata": {},
+   "source": [
+    "## Test tile-based Updates\n",
+    "\n",
+    "Useful links:\n",
+    "\n",
+    "* https://docs.sqlalchemy.org/en/20/orm/queryguide/dml.html#orm-queryguide-upsert\n",
+    "* https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#sqlalchemy.dialects.postgresql.Insert.on_conflict_do_update.params.set_\n",
+    "* https://docs.sqlalchemy.org/en/20/tutorial/orm_data_manipulation.html#tutorial-orm-data-manipulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "3ca0e31d-7833-40e1-b62f-c5bf2d9bcbaa",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "with open(os.path.join(os.environ['DESI_ROOT'], 'users', os.environ['USER'], 'tiles-daily-cache.json'), 'w') as j:\n",
+    "    json.dump(dict(zip(tiles_table['TILEID'].tolist(), tiles_table['UPDATED'].tolist())), j)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "0b03f183-f833-440a-9fca-6e7fa6e0d9e8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with open(os.path.join(os.environ['DESI_ROOT'], 'users', os.environ['USER'], 'tiles-daily-cache.json')) as j:\n",
+    "    tiles_cache = json.load(j)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "a09119c2-2af7-46cd-9cc5-a8b3291b946d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "update_tiles_table = Table.read(current_tiles_file, format='fits', hdu='TILES')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "d7fc779b-82ec-45d5-8368-9ad62364719b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><i>Table length=26</i>\n",
+       "<table id=\"table140306113489520\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>TILEID</th><th>SURVEY</th><th>PROGRAM</th><th>FAPRGRM</th><th>FAFLAVOR</th><th>NEXP</th><th>EXPTIME</th><th>TILERA</th><th>TILEDEC</th><th>EFFTIME_ETC</th><th>EFFTIME_SPEC</th><th>EFFTIME_GFA</th><th>GOALTIME</th><th>OBSSTATUS</th><th>LRG_EFFTIME_DARK</th><th>ELG_EFFTIME_DARK</th><th>BGS_EFFTIME_BRIGHT</th><th>LYA_EFFTIME_DARK</th><th>GOALTYPE</th><th>MINTFRAC</th><th>LASTNIGHT</th><th>UPDATED</th></tr></thead>\n",
+       "<thead><tr><th>int64</th><th>bytes20</th><th>bytes6</th><th>bytes20</th><th>bytes20</th><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>bytes20</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>bytes20</th><th>float64</th><th>int64</th><th>bytes24</th></tr></thead>\n",
+       "<tr><td>6498</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>949.7</td><td>20.467</td><td>28.44</td><td>1013.4</td><td>1019.5</td><td>1050.2</td><td>1000.0</td><td>obsend</td><td>1019.5</td><td>1078.6</td><td>983.0</td><td>1354.0</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
+       "<tr><td>8122</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1646.5</td><td>331.757</td><td>-13.178</td><td>1006.0</td><td>1122.4</td><td>1153.2</td><td>1000.0</td><td>obsend</td><td>1122.4</td><td>1122.3</td><td>1134.1</td><td>1648.2</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
+       "<tr><td>6757</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>865.6</td><td>2.874</td><td>27.131</td><td>1008.7</td><td>968.6</td><td>1079.3</td><td>1000.0</td><td>obsend</td><td>968.6</td><td>989.3</td><td>951.2</td><td>1410.0</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
+       "<tr><td>6501</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1084.4</td><td>28.043</td><td>28.166</td><td>1009.9</td><td>1032.8</td><td>1052.0</td><td>1000.0</td><td>obsend</td><td>1032.8</td><td>1076.8</td><td>1006.2</td><td>1395.9</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
+       "<tr><td>6225</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1487.1</td><td>336.749</td><td>-12.178</td><td>1006.3</td><td>1105.7</td><td>1098.3</td><td>1000.0</td><td>obsend</td><td>1105.7</td><td>1114.0</td><td>1108.5</td><td>1551.7</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
+       "<tr><td>1518</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1439.5</td><td>347.602</td><td>-12.842</td><td>1009.4</td><td>1051.2</td><td>1077.8</td><td>1000.0</td><td>obsend</td><td>1051.2</td><td>1055.7</td><td>1063.2</td><td>1506.5</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
+       "<tr><td>2471</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1330.3</td><td>37.973</td><td>-17.363</td><td>1002.7</td><td>1075.4</td><td>1021.0</td><td>1000.0</td><td>obsend</td><td>1075.4</td><td>1087.1</td><td>1081.5</td><td>1533.5</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
+       "<tr><td>1867</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1648.9</td><td>327.328</td><td>-10.39</td><td>1004.7</td><td>1117.2</td><td>1112.6</td><td>1000.0</td><td>obsend</td><td>1117.2</td><td>1128.8</td><td>1124.2</td><td>1598.3</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
+       "<tr><td>1804</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1078.6</td><td>30.674</td><td>25.605</td><td>1004.0</td><td>1065.7</td><td>1048.9</td><td>1000.0</td><td>obsend</td><td>1065.7</td><td>1129.3</td><td>1020.2</td><td>1284.4</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
+       "<tr><td>1549</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1421.0</td><td>354.576</td><td>-13.541</td><td>1007.8</td><td>1011.6</td><td>1110.7</td><td>1000.0</td><td>obsend</td><td>1011.6</td><td>1004.5</td><td>1025.6</td><td>1446.9</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
+       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
+       "<tr><td>8725</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1386.8</td><td>46.002</td><td>-15.237</td><td>1008.0</td><td>1097.0</td><td>1121.7</td><td>1000.0</td><td>obsend</td><td>1097.0</td><td>1116.5</td><td>1088.4</td><td>1475.6</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
+       "<tr><td>8732</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1666.4</td><td>43.883</td><td>-17.885</td><td>1007.4</td><td>1060.9</td><td>1071.1</td><td>1000.0</td><td>obsend</td><td>1060.9</td><td>1089.1</td><td>1069.0</td><td>1402.3</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
+       "<tr><td>9745</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1377.8</td><td>121.305</td><td>48.902</td><td>1007.1</td><td>1096.9</td><td>1053.0</td><td>1000.0</td><td>obsend</td><td>1096.9</td><td>1131.8</td><td>1085.7</td><td>1419.2</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
+       "<tr><td>9763</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1482.4</td><td>119.642</td><td>54.77</td><td>1011.2</td><td>1166.9</td><td>1132.8</td><td>1000.0</td><td>obsend</td><td>1166.9</td><td>1153.0</td><td>1157.6</td><td>1652.3</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
+       "<tr><td>11376</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1059.4</td><td>30.769</td><td>19.704</td><td>1007.5</td><td>987.9</td><td>1196.8</td><td>1000.0</td><td>obsend</td><td>987.9</td><td>1059.9</td><td>947.7</td><td>1253.9</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
+       "<tr><td>20973</td><td>main</td><td>bright</td><td>bright</td><td>mainbright</td><td>1</td><td>405.9</td><td>130.595</td><td>40.986</td><td>35.2</td><td>38.7</td><td>42.5</td><td>180.0</td><td>obsstart</td><td>32.4</td><td>38.6</td><td>38.7</td><td>49.5</td><td>bright</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
+       "<tr><td>27138</td><td>main</td><td>bright</td><td>bright</td><td>mainbright</td><td>1</td><td>884.9</td><td>334.949</td><td>-4.464</td><td>182.8</td><td>247.5</td><td>234.2</td><td>180.0</td><td>obsend</td><td>241.2</td><td>244.2</td><td>247.5</td><td>174.7</td><td>bright</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
+       "<tr><td>1516</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1530.1</td><td>344.211</td><td>-12.42</td><td>1007.0</td><td>1074.2</td><td>1124.7</td><td>1000.0</td><td>obsend</td><td>1074.2</td><td>1074.6</td><td>1085.2</td><td>1536.0</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
+       "<tr><td>27152</td><td>main</td><td>bright</td><td>bright</td><td>mainbright</td><td>1</td><td>1220.1</td><td>318.789</td><td>-4.707</td><td>181.2</td><td>242.3</td><td>168.1</td><td>180.0</td><td>obsend</td><td>232.0</td><td>238.2</td><td>242.3</td><td>165.8</td><td>bright</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
+       "<tr><td>8264</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>804.6</td><td>7.047</td><td>27.959</td><td>1011.2</td><td>883.3</td><td>1064.4</td><td>1000.0</td><td>obsend</td><td>883.3</td><td>897.2</td><td>850.4</td><td>1460.9</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
+       "</table></div>"
+      ],
+      "text/plain": [
+       "<Table length=26>\n",
+       "TILEID  SURVEY PROGRAM FAPRGRM ... MINTFRAC LASTNIGHT         UPDATED         \n",
+       "int64  bytes20  bytes6 bytes20 ... float64    int64           bytes24         \n",
+       "------ ------- ------- ------- ... -------- --------- ------------------------\n",
+       "  6498    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
+       "  8122    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
+       "  6757    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
+       "  6501    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
+       "  6225    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
+       "  1518    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
+       "  2471    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
+       "  1867    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
+       "  1804    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
+       "  1549    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
+       "   ...     ...     ...     ... ...      ...       ...                      ...\n",
+       "  8725    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
+       "  8732    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
+       "  9745    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
+       "  9763    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
+       " 11376    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
+       " 20973    main  bright  bright ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
+       " 27138    main  bright  bright ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
+       "  1516    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
+       " 27152    main  bright  bright ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
+       "  8264    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cached_tiles = np.array(list(map(int, tiles_cache.keys())))\n",
+    "new_tiles = ~np.in1d(update_tiles_table['TILEID'], cached_tiles)\n",
+    "updated_tiles = np.zeros((len(update_tiles_table), ), dtype=bool)\n",
+    "for tileid in tiles_cache:\n",
+    "    t = int(tileid)\n",
+    "    w = np.where(update_tiles_table['TILEID'] == t)[0]\n",
+    "    assert len(w) == 1\n",
+    "    if update_tiles_table['UPDATED'][w] == tiles_cache[tileid]:\n",
+    "        pass\n",
+    "    elif update_tiles_table['UPDATED'][w] > tiles_cache[tileid]:\n",
+    "        # print(\"{0} > {1}\".format(update_tiles_table['UPDATED'][w], tiles_cache[tileid]))\n",
+    "        updated_tiles[w] = True\n",
+    "    else:\n",
+    "        print(\"Something weird happened.\")\n",
+    "update_tiles_table[new_tiles]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "444c8365-eb29-428e-ab7f-5b3aa3fc2b88",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><i>Table length=2</i>\n",
+       "<table id=\"table140305694153968\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>TILEID</th><th>SURVEY</th><th>PROGRAM</th><th>FAPRGRM</th><th>FAFLAVOR</th><th>NEXP</th><th>EXPTIME</th><th>TILERA</th><th>TILEDEC</th><th>EFFTIME_ETC</th><th>EFFTIME_SPEC</th><th>EFFTIME_GFA</th><th>GOALTIME</th><th>OBSSTATUS</th><th>LRG_EFFTIME_DARK</th><th>ELG_EFFTIME_DARK</th><th>BGS_EFFTIME_BRIGHT</th><th>LYA_EFFTIME_DARK</th><th>GOALTYPE</th><th>MINTFRAC</th><th>LASTNIGHT</th><th>UPDATED</th></tr></thead>\n",
+       "<thead><tr><th>int64</th><th>bytes20</th><th>bytes6</th><th>bytes20</th><th>bytes20</th><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>bytes20</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>bytes20</th><th>float64</th><th>int64</th><th>bytes24</th></tr></thead>\n",
+       "<tr><td>22957</td><td>main</td><td>bright</td><td>bright</td><td>mainbright</td><td>3</td><td>1065.7</td><td>128.532</td><td>30.959</td><td>192.7</td><td>180.0</td><td>214.5</td><td>180.0</td><td>obsend</td><td>157.4</td><td>172.7</td><td>180.0</td><td>206.2</td><td>bright</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
+       "<tr><td>27443</td><td>main</td><td>bright</td><td>bright</td><td>mainbright</td><td>2</td><td>964.4</td><td>115.927</td><td>28.387</td><td>157.4</td><td>184.0</td><td>192.1</td><td>180.0</td><td>obsend</td><td>167.5</td><td>196.2</td><td>184.0</td><td>188.4</td><td>bright</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
+       "</table></div>"
+      ],
+      "text/plain": [
+       "<Table length=2>\n",
+       "TILEID  SURVEY PROGRAM FAPRGRM ... MINTFRAC LASTNIGHT         UPDATED         \n",
+       "int64  bytes20  bytes6 bytes20 ... float64    int64           bytes24         \n",
+       "------ ------- ------- ------- ... -------- --------- ------------------------\n",
+       " 22957    main  bright  bright ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
+       " 27443    main  bright  bright ...     0.85  20241007 2024-10-08T21:31:03-0700"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "update_tiles_table[updated_tiles]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "157947d9-d1d5-42fd-8984-9ceb407c06ad",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "load_new_tiles = db.Tile.convert(update_tiles_table, row_index=new_tiles)\n",
+    "load_updated_tiles = db.Tile.convert(update_tiles_table, row_index=updated_tiles)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7f39ef0-cdeb-4b67-b6f9-24d49091e378",
+   "metadata": {},
+   "source": [
+    "### Find exposures associated with new and updated tiles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "d45408e3-2982-4e60-941c-da1d034fb36b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "update_exposures_table = Table.read(current_exposures_file, format='fits', hdu='EXPOSURES')\n",
+    "update_frames_table = Table.read(current_exposures_file, format='fits', hdu='FRAMES')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "ebe3108f-438b-427f-ac8d-0e58020c6d39",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "([Tile(tileid=6498),\n",
+       "  Tile(tileid=8122),\n",
+       "  Tile(tileid=6757),\n",
+       "  Tile(tileid=6501),\n",
+       "  Tile(tileid=6225),\n",
+       "  Tile(tileid=1518),\n",
+       "  Tile(tileid=2471),\n",
+       "  Tile(tileid=1867),\n",
+       "  Tile(tileid=1804),\n",
+       "  Tile(tileid=1549),\n",
+       "  Tile(tileid=8259),\n",
+       "  Tile(tileid=5381),\n",
+       "  Tile(tileid=8261),\n",
+       "  Tile(tileid=9123),\n",
+       "  Tile(tileid=8495),\n",
+       "  Tile(tileid=8496),\n",
+       "  Tile(tileid=8725),\n",
+       "  Tile(tileid=8732),\n",
+       "  Tile(tileid=9745),\n",
+       "  Tile(tileid=9763),\n",
+       "  Tile(tileid=11376),\n",
+       "  Tile(tileid=20973),\n",
+       "  Tile(tileid=27138),\n",
+       "  Tile(tileid=1516),\n",
+       "  Tile(tileid=27152),\n",
+       "  Tile(tileid=8264),\n",
+       "  Tile(tileid=22957),\n",
+       "  Tile(tileid=27443)],\n",
+       " [Exposure(night=20241007, expid=256820, tileid=6498),\n",
+       "  Exposure(night=20241007, expid=256808, tileid=8122),\n",
+       "  Exposure(night=20241007, expid=256816, tileid=6757),\n",
+       "  Exposure(night=20241007, expid=256823, tileid=6501),\n",
+       "  Exposure(night=20241007, expid=256809, tileid=6225),\n",
+       "  Exposure(night=20241007, expid=256811, tileid=1518),\n",
+       "  Exposure(night=20241007, expid=256824, tileid=2471),\n",
+       "  Exposure(night=20241007, expid=256807, tileid=1867),\n",
+       "  Exposure(night=20241007, expid=256822, tileid=1804),\n",
+       "  Exposure(night=20241007, expid=256812, tileid=1549),\n",
+       "  Exposure(night=20241007, expid=256819, tileid=8259),\n",
+       "  Exposure(night=20241007, expid=256813, tileid=5381),\n",
+       "  Exposure(night=20241007, expid=256818, tileid=8261),\n",
+       "  Exposure(night=20241007, expid=256805, tileid=9123),\n",
+       "  Exposure(night=20241007, expid=256806, tileid=9123),\n",
+       "  Exposure(night=20241007, expid=256814, tileid=8495),\n",
+       "  Exposure(night=20241007, expid=256815, tileid=8496),\n",
+       "  Exposure(night=20241007, expid=256825, tileid=8725),\n",
+       "  Exposure(night=20241007, expid=256826, tileid=8732),\n",
+       "  Exposure(night=20241007, expid=256828, tileid=9745),\n",
+       "  Exposure(night=20241007, expid=256827, tileid=9763),\n",
+       "  Exposure(night=20241007, expid=256821, tileid=11376),\n",
+       "  Exposure(night=20241007, expid=256831, tileid=20973),\n",
+       "  Exposure(night=20241007, expid=256804, tileid=27138),\n",
+       "  Exposure(night=20241007, expid=256810, tileid=1516),\n",
+       "  Exposure(night=20241007, expid=256803, tileid=27152),\n",
+       "  Exposure(night=20241007, expid=256817, tileid=8264),\n",
+       "  Exposure(night=20241006, expid=256674, tileid=22957),\n",
+       "  Exposure(night=20241007, expid=256829, tileid=22957),\n",
+       "  Exposure(night=20240921, expid=254400, tileid=27443),\n",
+       "  Exposure(night=20241007, expid=256830, tileid=27443)])"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "load_tiles = list()\n",
+    "load_exposures = list() \n",
+    "for new_tile in (load_new_tiles + load_updated_tiles):\n",
+    "    row_index = np.where((update_exposures_table['TILEID'] == new_tile.tileid) & (update_exposures_table['EFFTIME_SPEC'] > 0))[0]\n",
+    "    if len(row_index) > 0:\n",
+    "        load_tiles.append(new_tile)\n",
+    "        load_exposures += db.Exposure.convert(update_exposures_table, row_index=row_index)\n",
+    "    else:\n",
+    "        print(\"ERROR: No valid exposures found for tile {0:d}, even though EFFTIME_SPEC == {1:f}!\".format(new_tile.tileid, new_tile.efftime_spec))\n",
+    "        bad_index = np.where((update_exposures_table['TILEID'] == new_tile.tileid))[0]\n",
+    "        print(update_exposures_table[['EXPID', 'NIGHT', 'MJD', 'EFFTIME_SPEC']][bad_index])\n",
+    "        bad_tiles.append(new_tile)\n",
+    "load_tiles, load_exposures"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 96,
+   "id": "b6e94fce-08bc-4361-bdf2-0ba6c7f2aab4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "load_frames = list()\n",
+    "for exposure in load_exposures:\n",
+    "    row_index = np.where(update_frames_table['EXPID'] == exposure.expid)[0]\n",
+    "    assert len(row_index) > 0\n",
+    "    load_frames += db.Frame.convert(update_frames_table, row_index=row_index)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "5104bb5d-2706-4f51-ad72-2c5989a95424",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from sqlalchemy.dialects.postgresql import insert"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "id": "1f09208d-8c25-4758-9e15-24f69166f76e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INSERT INTO daily.version (id, package, version) VALUES (%(id_m0)s, %(package_m0)s, %(version_m0)s), (%(id_m1)s, %(package_m1)s, %(version_m1)s), (%(id_m2)s, %(package_m2)s, %(version_m2)s) ON CONFLICT (id) DO UPDATE SET package = excluded.package, version = excluded.version\n"
+     ]
+    }
+   ],
+   "source": [
+    "stmt = insert(db.Version).values([{'id': 11, 'package': 'foo', 'version': '1.2.6'}, {'id': 10, 'package': 'tiles', 'version': 'main.test6'}, {'id': 12, 'package': 'bar', 'version': '3.4.5'}])\n",
+    "# stmt = stmt.on_conflict_do_update(index_elements=[db.Version.id], set_=dict(package=getattr(stmt.excluded, 'package'), version=getattr(stmt.excluded, 'version')))\n",
+    "stmt = stmt.on_conflict_do_update(index_elements=[db.Version.id], set_=dict([(c, getattr(stmt.excluded, c.name)) for c in db.Version.__table__.columns if c.name != 'id']))\n",
+    "print(stmt)\n",
+    "# db.dbSession.rollback()\n",
+    "db.dbSession.execute(stmt)\n",
+    "db.dbSession.commit()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 76,
+   "id": "1f0d8062-740f-46a4-8eb0-fc93cb4b5c35",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "load_tiles_as_dict = list()\n",
+    "for t in load_tiles:\n",
+    "    tt = t.__dict__.copy()\n",
+    "    del tt['_sa_instance_state']\n",
+    "    load_tiles_as_dict.append(tt)\n",
+    "stmt = insert(db.Tile).values(load_tiles_as_dict)\n",
+    "stmt = stmt.on_conflict_do_update(index_elements=[db.Tile.tileid], set_=dict([(c, getattr(stmt.excluded, c.name)) for c in db.Tile.__table__.columns if c.name != 'tileid']))\n",
+    "db.dbSession.execute(stmt)\n",
+    "db.dbSession.commit()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "id": "32163199-fec8-4e03-bf18-9fc21c68e6f8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(<sqlalchemy.orm.attributes.InstrumentedAttribute at 0x7f9bda1a6520>,\n",
+       " Column('expid', Integer(), table=<exposure>, primary_key=True, nullable=False))"
+      ]
+     },
+     "execution_count": 85,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "getattr(load_exposures[0].__class__, 'expid'), [c for c in load_exposures[0].__class__.__table__.columns if c.primary_key][0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "id": "56a310b4-fb2e-4a40-88ed-2b9609379422",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def upsert(rows):\n",
+    "    \"\"\"Convert a list of ORM objects into an 'UPSERT' statement.\n",
+    "    \"\"\"\n",
+    "    cls = rows[0].__class__\n",
+    "    pk = [c for c in cls.__table__.columns if c.primary_key][0]\n",
+    "    inserts = list()\n",
+    "    for row in rows:\n",
+    "        rr = row.__dict__.copy()\n",
+    "        del rr['_sa_instance_state']\n",
+    "        inserts.append(rr)\n",
+    "    stmt = insert(cls).values(inserts)\n",
+    "    stmt = stmt.on_conflict_do_update(index_elements=[getattr(cls, pk.name)], set_=dict([(c, getattr(stmt.excluded, c.name)) for c in cls.__table__.columns if c.name != pk.name]))\n",
+    "    return stmt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 90,
+   "id": "12ba3979-e2fb-4119-a79a-f7d6e413952a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INSERT INTO daily.exposure (night, expid, tileid, tilera, tiledec, date_obs, mjd, survey, program, faprgrm, faflavor, exptime, efftime_spec, goaltime, goaltype, mintfrac, airmass, ebv, seeing_etc, efftime_etc, tsnr2_elg, tsnr2_qso, tsnr2_lrg, tsnr2_lya, tsnr2_bgs, tsnr2_gpbdark, tsnr2_gpbbright, tsnr2_gpbbackup, lrg_efftime_dark, elg_efftime_dark, bgs_efftime_bright, lya_efftime_dark, gpb_efftime_dark, gpb_efftime_bright, gpb_efftime_backup, transparency_gfa, seeing_gfa, fiber_fracflux_gfa, fiber_fracflux_elg_gfa, fiber_fracflux_bgs_gfa, fiberfac_gfa, fiberfac_elg_gfa, fiberfac_bgs_gfa, airmass_gfa, sky_mag_ab_gfa, sky_mag_g_spec, sky_mag_r_spec, sky_mag_z_spec, efftime_gfa, efftime_dark_gfa, efftime_bright_gfa, efftime_backup_gfa) VALUES (%(night_m0)s, %(expid_m0)s, %(tileid_m0)s, %(tilera_m0)s, %(tiledec_m0)s, %(date_obs_m0)s, %(mjd_m0)s, %(survey_m0)s, %(program_m0)s, %(faprgrm_m0)s, %(faflavor_m0)s, %(exptime_m0)s, %(efftime_spec_m0)s, %(goaltime_m0)s, %(goaltype_m0)s, %(mintfrac_m0)s, %(airmass_m0)s, %(ebv_m0)s, %(seeing_etc_m0)s, %(efftime_etc_m0)s, %(tsnr2_elg_m0)s, %(tsnr2_qso_m0)s, %(tsnr2_lrg_m0)s, %(tsnr2_lya_m0)s, %(tsnr2_bgs_m0)s, %(tsnr2_gpbdark_m0)s, %(tsnr2_gpbbright_m0)s, %(tsnr2_gpbbackup_m0)s, %(lrg_efftime_dark_m0)s, %(elg_efftime_dark_m0)s, %(bgs_efftime_bright_m0)s, %(lya_efftime_dark_m0)s, %(gpb_efftime_dark_m0)s, %(gpb_efftime_bright_m0)s, %(gpb_efftime_backup_m0)s, %(transparency_gfa_m0)s, %(seeing_gfa_m0)s, %(fiber_fracflux_gfa_m0)s, %(fiber_fracflux_elg_gfa_m0)s, %(fiber_fracflux_bgs_gfa_m0)s, %(fiberfac_gfa_m0)s, %(fiberfac_elg_gfa_m0)s, %(fiberfac_bgs_gfa_m0)s, %(airmass_gfa_m0)s, %(sky_mag_ab_gfa_m0)s, %(sky_mag_g_spec_m0)s, %(sky_mag_r_spec_m0)s, %(sky_mag_z_spec_m0)s, %(efftime_gfa_m0)s, %(efftime_dark_gfa_m0)s, %(efftime_bright_gfa_m0)s, %(efftime_backup_gfa_m0)s), (%(night_m1)s, %(expid_m1)s, %(tileid_m1)s, %(tilera_m1)s, %(tiledec_m1)s, %(date_obs_m1)s, %(mjd_m1)s, %(survey_m1)s, %(program_m1)s, %(faprgrm_m1)s, %(faflavor_m1)s, %(exptime_m1)s, %(efftime_spec_m1)s, %(goaltime_m1)s, %(goaltype_m1)s, %(mintfrac_m1)s, %(airmass_m1)s, %(ebv_m1)s, %(seeing_etc_m1)s, %(efftime_etc_m1)s, %(tsnr2_elg_m1)s, %(tsnr2_qso_m1)s, %(tsnr2_lrg_m1)s, %(tsnr2_lya_m1)s, %(tsnr2_bgs_m1)s, %(tsnr2_gpbdark_m1)s, %(tsnr2_gpbbright_m1)s, %(tsnr2_gpbbackup_m1)s, %(lrg_efftime_dark_m1)s, %(elg_efftime_dark_m1)s, %(bgs_efftime_bright_m1)s, %(lya_efftime_dark_m1)s, %(gpb_efftime_dark_m1)s, %(gpb_efftime_bright_m1)s, %(gpb_efftime_backup_m1)s, %(transparency_gfa_m1)s, %(seeing_gfa_m1)s, %(fiber_fracflux_gfa_m1)s, %(fiber_fracflux_elg_gfa_m1)s, %(fiber_fracflux_bgs_gfa_m1)s, %(fiberfac_gfa_m1)s, %(fiberfac_elg_gfa_m1)s, %(fiberfac_bgs_gfa_m1)s, %(airmass_gfa_m1)s, %(sky_mag_ab_gfa_m1)s, %(sky_mag_g_spec_m1)s, %(sky_mag_r_spec_m1)s, %(sky_mag_z_spec_m1)s, %(efftime_gfa_m1)s, %(efftime_dark_gfa_m1)s, %(efftime_bright_gfa_m1)s, %(efftime_backup_gfa_m1)s), (%(night_m2)s, %(expid_m2)s, %(tileid_m2)s, %(tilera_m2)s, %(tiledec_m2)s, %(date_obs_m2)s, %(mjd_m2)s, %(survey_m2)s, %(program_m2)s, %(faprgrm_m2)s, %(faflavor_m2)s, %(exptime_m2)s, %(efftime_spec_m2)s, %(goaltime_m2)s, %(goaltype_m2)s, %(mintfrac_m2)s, %(airmass_m2)s, %(ebv_m2)s, %(seeing_etc_m2)s, %(efftime_etc_m2)s, %(tsnr2_elg_m2)s, %(tsnr2_qso_m2)s, %(tsnr2_lrg_m2)s, %(tsnr2_lya_m2)s, %(tsnr2_bgs_m2)s, %(tsnr2_gpbdark_m2)s, %(tsnr2_gpbbright_m2)s, %(tsnr2_gpbbackup_m2)s, %(lrg_efftime_dark_m2)s, %(elg_efftime_dark_m2)s, %(bgs_efftime_bright_m2)s, %(lya_efftime_dark_m2)s, %(gpb_efftime_dark_m2)s, %(gpb_efftime_bright_m2)s, %(gpb_efftime_backup_m2)s, %(transparency_gfa_m2)s, %(seeing_gfa_m2)s, %(fiber_fracflux_gfa_m2)s, %(fiber_fracflux_elg_gfa_m2)s, %(fiber_fracflux_bgs_gfa_m2)s, %(fiberfac_gfa_m2)s, %(fiberfac_elg_gfa_m2)s, %(fiberfac_bgs_gfa_m2)s, %(airmass_gfa_m2)s, %(sky_mag_ab_gfa_m2)s, %(sky_mag_g_spec_m2)s, %(sky_mag_r_spec_m2)s, %(sky_mag_z_spec_m2)s, %(efftime_gfa_m2)s, %(efftime_dark_gfa_m2)s, %(efftime_bright_gfa_m2)s, %(efftime_backup_gfa_m2)s), (%(night_m3)s, %(expid_m3)s, %(tileid_m3)s, %(tilera_m3)s, %(tiledec_m3)s, %(date_obs_m3)s, %(mjd_m3)s, %(survey_m3)s, %(program_m3)s, %(faprgrm_m3)s, %(faflavor_m3)s, %(exptime_m3)s, %(efftime_spec_m3)s, %(goaltime_m3)s, %(goaltype_m3)s, %(mintfrac_m3)s, %(airmass_m3)s, %(ebv_m3)s, %(seeing_etc_m3)s, %(efftime_etc_m3)s, %(tsnr2_elg_m3)s, %(tsnr2_qso_m3)s, %(tsnr2_lrg_m3)s, %(tsnr2_lya_m3)s, %(tsnr2_bgs_m3)s, %(tsnr2_gpbdark_m3)s, %(tsnr2_gpbbright_m3)s, %(tsnr2_gpbbackup_m3)s, %(lrg_efftime_dark_m3)s, %(elg_efftime_dark_m3)s, %(bgs_efftime_bright_m3)s, %(lya_efftime_dark_m3)s, %(gpb_efftime_dark_m3)s, %(gpb_efftime_bright_m3)s, %(gpb_efftime_backup_m3)s, %(transparency_gfa_m3)s, %(seeing_gfa_m3)s, %(fiber_fracflux_gfa_m3)s, %(fiber_fracflux_elg_gfa_m3)s, %(fiber_fracflux_bgs_gfa_m3)s, %(fiberfac_gfa_m3)s, %(fiberfac_elg_gfa_m3)s, %(fiberfac_bgs_gfa_m3)s, %(airmass_gfa_m3)s, %(sky_mag_ab_gfa_m3)s, %(sky_mag_g_spec_m3)s, %(sky_mag_r_spec_m3)s, %(sky_mag_z_spec_m3)s, %(efftime_gfa_m3)s, %(efftime_dark_gfa_m3)s, %(efftime_bright_gfa_m3)s, %(efftime_backup_gfa_m3)s), (%(night_m4)s, %(expid_m4)s, %(tileid_m4)s, %(tilera_m4)s, %(tiledec_m4)s, %(date_obs_m4)s, %(mjd_m4)s, %(survey_m4)s, %(program_m4)s, %(faprgrm_m4)s, %(faflavor_m4)s, %(exptime_m4)s, %(efftime_spec_m4)s, %(goaltime_m4)s, %(goaltype_m4)s, %(mintfrac_m4)s, %(airmass_m4)s, %(ebv_m4)s, %(seeing_etc_m4)s, %(efftime_etc_m4)s, %(tsnr2_elg_m4)s, %(tsnr2_qso_m4)s, %(tsnr2_lrg_m4)s, %(tsnr2_lya_m4)s, %(tsnr2_bgs_m4)s, %(tsnr2_gpbdark_m4)s, %(tsnr2_gpbbright_m4)s, %(tsnr2_gpbbackup_m4)s, %(lrg_efftime_dark_m4)s, %(elg_efftime_dark_m4)s, %(bgs_efftime_bright_m4)s, %(lya_efftime_dark_m4)s, %(gpb_efftime_dark_m4)s, %(gpb_efftime_bright_m4)s, %(gpb_efftime_backup_m4)s, %(transparency_gfa_m4)s, %(seeing_gfa_m4)s, %(fiber_fracflux_gfa_m4)s, %(fiber_fracflux_elg_gfa_m4)s, %(fiber_fracflux_bgs_gfa_m4)s, %(fiberfac_gfa_m4)s, %(fiberfac_elg_gfa_m4)s, %(fiberfac_bgs_gfa_m4)s, %(airmass_gfa_m4)s, %(sky_mag_ab_gfa_m4)s, %(sky_mag_g_spec_m4)s, %(sky_mag_r_spec_m4)s, %(sky_mag_z_spec_m4)s, %(efftime_gfa_m4)s, %(efftime_dark_gfa_m4)s, %(efftime_bright_gfa_m4)s, %(efftime_backup_gfa_m4)s), (%(night_m5)s, %(expid_m5)s, %(tileid_m5)s, %(tilera_m5)s, %(tiledec_m5)s, %(date_obs_m5)s, %(mjd_m5)s, %(survey_m5)s, %(program_m5)s, %(faprgrm_m5)s, %(faflavor_m5)s, %(exptime_m5)s, %(efftime_spec_m5)s, %(goaltime_m5)s, %(goaltype_m5)s, %(mintfrac_m5)s, %(airmass_m5)s, %(ebv_m5)s, %(seeing_etc_m5)s, %(efftime_etc_m5)s, %(tsnr2_elg_m5)s, %(tsnr2_qso_m5)s, %(tsnr2_lrg_m5)s, %(tsnr2_lya_m5)s, %(tsnr2_bgs_m5)s, %(tsnr2_gpbdark_m5)s, %(tsnr2_gpbbright_m5)s, %(tsnr2_gpbbackup_m5)s, %(lrg_efftime_dark_m5)s, %(elg_efftime_dark_m5)s, %(bgs_efftime_bright_m5)s, %(lya_efftime_dark_m5)s, %(gpb_efftime_dark_m5)s, %(gpb_efftime_bright_m5)s, %(gpb_efftime_backup_m5)s, %(transparency_gfa_m5)s, %(seeing_gfa_m5)s, %(fiber_fracflux_gfa_m5)s, %(fiber_fracflux_elg_gfa_m5)s, %(fiber_fracflux_bgs_gfa_m5)s, %(fiberfac_gfa_m5)s, %(fiberfac_elg_gfa_m5)s, %(fiberfac_bgs_gfa_m5)s, %(airmass_gfa_m5)s, %(sky_mag_ab_gfa_m5)s, %(sky_mag_g_spec_m5)s, %(sky_mag_r_spec_m5)s, %(sky_mag_z_spec_m5)s, %(efftime_gfa_m5)s, %(efftime_dark_gfa_m5)s, %(efftime_bright_gfa_m5)s, %(efftime_backup_gfa_m5)s), (%(night_m6)s, %(expid_m6)s, %(tileid_m6)s, %(tilera_m6)s, %(tiledec_m6)s, %(date_obs_m6)s, %(mjd_m6)s, %(survey_m6)s, %(program_m6)s, %(faprgrm_m6)s, %(faflavor_m6)s, %(exptime_m6)s, %(efftime_spec_m6)s, %(goaltime_m6)s, %(goaltype_m6)s, %(mintfrac_m6)s, %(airmass_m6)s, %(ebv_m6)s, %(seeing_etc_m6)s, %(efftime_etc_m6)s, %(tsnr2_elg_m6)s, %(tsnr2_qso_m6)s, %(tsnr2_lrg_m6)s, %(tsnr2_lya_m6)s, %(tsnr2_bgs_m6)s, %(tsnr2_gpbdark_m6)s, %(tsnr2_gpbbright_m6)s, %(tsnr2_gpbbackup_m6)s, %(lrg_efftime_dark_m6)s, %(elg_efftime_dark_m6)s, %(bgs_efftime_bright_m6)s, %(lya_efftime_dark_m6)s, %(gpb_efftime_dark_m6)s, %(gpb_efftime_bright_m6)s, %(gpb_efftime_backup_m6)s, %(transparency_gfa_m6)s, %(seeing_gfa_m6)s, %(fiber_fracflux_gfa_m6)s, %(fiber_fracflux_elg_gfa_m6)s, %(fiber_fracflux_bgs_gfa_m6)s, %(fiberfac_gfa_m6)s, %(fiberfac_elg_gfa_m6)s, %(fiberfac_bgs_gfa_m6)s, %(airmass_gfa_m6)s, %(sky_mag_ab_gfa_m6)s, %(sky_mag_g_spec_m6)s, %(sky_mag_r_spec_m6)s, %(sky_mag_z_spec_m6)s, %(efftime_gfa_m6)s, %(efftime_dark_gfa_m6)s, %(efftime_bright_gfa_m6)s, %(efftime_backup_gfa_m6)s), (%(night_m7)s, %(expid_m7)s, %(tileid_m7)s, %(tilera_m7)s, %(tiledec_m7)s, %(date_obs_m7)s, %(mjd_m7)s, %(survey_m7)s, %(program_m7)s, %(faprgrm_m7)s, %(faflavor_m7)s, %(exptime_m7)s, %(efftime_spec_m7)s, %(goaltime_m7)s, %(goaltype_m7)s, %(mintfrac_m7)s, %(airmass_m7)s, %(ebv_m7)s, %(seeing_etc_m7)s, %(efftime_etc_m7)s, %(tsnr2_elg_m7)s, %(tsnr2_qso_m7)s, %(tsnr2_lrg_m7)s, %(tsnr2_lya_m7)s, %(tsnr2_bgs_m7)s, %(tsnr2_gpbdark_m7)s, %(tsnr2_gpbbright_m7)s, %(tsnr2_gpbbackup_m7)s, %(lrg_efftime_dark_m7)s, %(elg_efftime_dark_m7)s, %(bgs_efftime_bright_m7)s, %(lya_efftime_dark_m7)s, %(gpb_efftime_dark_m7)s, %(gpb_efftime_bright_m7)s, %(gpb_efftime_backup_m7)s, %(transparency_gfa_m7)s, %(seeing_gfa_m7)s, %(fiber_fracflux_gfa_m7)s, %(fiber_fracflux_elg_gfa_m7)s, %(fiber_fracflux_bgs_gfa_m7)s, %(fiberfac_gfa_m7)s, %(fiberfac_elg_gfa_m7)s, %(fiberfac_bgs_gfa_m7)s, %(airmass_gfa_m7)s, %(sky_mag_ab_gfa_m7)s, %(sky_mag_g_spec_m7)s, %(sky_mag_r_spec_m7)s, %(sky_mag_z_spec_m7)s, %(efftime_gfa_m7)s, %(efftime_dark_gfa_m7)s, %(efftime_bright_gfa_m7)s, %(efftime_backup_gfa_m7)s), (%(night_m8)s, %(expid_m8)s, %(tileid_m8)s, %(tilera_m8)s, %(tiledec_m8)s, %(date_obs_m8)s, %(mjd_m8)s, %(survey_m8)s, %(program_m8)s, %(faprgrm_m8)s, %(faflavor_m8)s, %(exptime_m8)s, %(efftime_spec_m8)s, %(goaltime_m8)s, %(goaltype_m8)s, %(mintfrac_m8)s, %(airmass_m8)s, %(ebv_m8)s, %(seeing_etc_m8)s, %(efftime_etc_m8)s, %(tsnr2_elg_m8)s, %(tsnr2_qso_m8)s, %(tsnr2_lrg_m8)s, %(tsnr2_lya_m8)s, %(tsnr2_bgs_m8)s, %(tsnr2_gpbdark_m8)s, %(tsnr2_gpbbright_m8)s, %(tsnr2_gpbbackup_m8)s, %(lrg_efftime_dark_m8)s, %(elg_efftime_dark_m8)s, %(bgs_efftime_bright_m8)s, %(lya_efftime_dark_m8)s, %(gpb_efftime_dark_m8)s, %(gpb_efftime_bright_m8)s, %(gpb_efftime_backup_m8)s, %(transparency_gfa_m8)s, %(seeing_gfa_m8)s, %(fiber_fracflux_gfa_m8)s, %(fiber_fracflux_elg_gfa_m8)s, %(fiber_fracflux_bgs_gfa_m8)s, %(fiberfac_gfa_m8)s, %(fiberfac_elg_gfa_m8)s, %(fiberfac_bgs_gfa_m8)s, %(airmass_gfa_m8)s, %(sky_mag_ab_gfa_m8)s, %(sky_mag_g_spec_m8)s, %(sky_mag_r_spec_m8)s, %(sky_mag_z_spec_m8)s, %(efftime_gfa_m8)s, %(efftime_dark_gfa_m8)s, %(efftime_bright_gfa_m8)s, %(efftime_backup_gfa_m8)s), (%(night_m9)s, %(expid_m9)s, %(tileid_m9)s, %(tilera_m9)s, %(tiledec_m9)s, %(date_obs_m9)s, %(mjd_m9)s, %(survey_m9)s, %(program_m9)s, %(faprgrm_m9)s, %(faflavor_m9)s, %(exptime_m9)s, %(efftime_spec_m9)s, %(goaltime_m9)s, %(goaltype_m9)s, %(mintfrac_m9)s, %(airmass_m9)s, %(ebv_m9)s, %(seeing_etc_m9)s, %(efftime_etc_m9)s, %(tsnr2_elg_m9)s, %(tsnr2_qso_m9)s, %(tsnr2_lrg_m9)s, %(tsnr2_lya_m9)s, %(tsnr2_bgs_m9)s, %(tsnr2_gpbdark_m9)s, %(tsnr2_gpbbright_m9)s, %(tsnr2_gpbbackup_m9)s, %(lrg_efftime_dark_m9)s, %(elg_efftime_dark_m9)s, %(bgs_efftime_bright_m9)s, %(lya_efftime_dark_m9)s, %(gpb_efftime_dark_m9)s, %(gpb_efftime_bright_m9)s, %(gpb_efftime_backup_m9)s, %(transparency_gfa_m9)s, %(seeing_gfa_m9)s, %(fiber_fracflux_gfa_m9)s, %(fiber_fracflux_elg_gfa_m9)s, %(fiber_fracflux_bgs_gfa_m9)s, %(fiberfac_gfa_m9)s, %(fiberfac_elg_gfa_m9)s, %(fiberfac_bgs_gfa_m9)s, %(airmass_gfa_m9)s, %(sky_mag_ab_gfa_m9)s, %(sky_mag_g_spec_m9)s, %(sky_mag_r_spec_m9)s, %(sky_mag_z_spec_m9)s, %(efftime_gfa_m9)s, %(efftime_dark_gfa_m9)s, %(efftime_bright_gfa_m9)s, %(efftime_backup_gfa_m9)s), (%(night_m10)s, %(expid_m10)s, %(tileid_m10)s, %(tilera_m10)s, %(tiledec_m10)s, %(date_obs_m10)s, %(mjd_m10)s, %(survey_m10)s, %(program_m10)s, %(faprgrm_m10)s, %(faflavor_m10)s, %(exptime_m10)s, %(efftime_spec_m10)s, %(goaltime_m10)s, %(goaltype_m10)s, %(mintfrac_m10)s, %(airmass_m10)s, %(ebv_m10)s, %(seeing_etc_m10)s, %(efftime_etc_m10)s, %(tsnr2_elg_m10)s, %(tsnr2_qso_m10)s, %(tsnr2_lrg_m10)s, %(tsnr2_lya_m10)s, %(tsnr2_bgs_m10)s, %(tsnr2_gpbdark_m10)s, %(tsnr2_gpbbright_m10)s, %(tsnr2_gpbbackup_m10)s, %(lrg_efftime_dark_m10)s, %(elg_efftime_dark_m10)s, %(bgs_efftime_bright_m10)s, %(lya_efftime_dark_m10)s, %(gpb_efftime_dark_m10)s, %(gpb_efftime_bright_m10)s, %(gpb_efftime_backup_m10)s, %(transparency_gfa_m10)s, %(seeing_gfa_m10)s, %(fiber_fracflux_gfa_m10)s, %(fiber_fracflux_elg_gfa_m10)s, %(fiber_fracflux_bgs_gfa_m10)s, %(fiberfac_gfa_m10)s, %(fiberfac_elg_gfa_m10)s, %(fiberfac_bgs_gfa_m10)s, %(airmass_gfa_m10)s, %(sky_mag_ab_gfa_m10)s, %(sky_mag_g_spec_m10)s, %(sky_mag_r_spec_m10)s, %(sky_mag_z_spec_m10)s, %(efftime_gfa_m10)s, %(efftime_dark_gfa_m10)s, %(efftime_bright_gfa_m10)s, %(efftime_backup_gfa_m10)s), (%(night_m11)s, %(expid_m11)s, %(tileid_m11)s, %(tilera_m11)s, %(tiledec_m11)s, %(date_obs_m11)s, %(mjd_m11)s, %(survey_m11)s, %(program_m11)s, %(faprgrm_m11)s, %(faflavor_m11)s, %(exptime_m11)s, %(efftime_spec_m11)s, %(goaltime_m11)s, %(goaltype_m11)s, %(mintfrac_m11)s, %(airmass_m11)s, %(ebv_m11)s, %(seeing_etc_m11)s, %(efftime_etc_m11)s, %(tsnr2_elg_m11)s, %(tsnr2_qso_m11)s, %(tsnr2_lrg_m11)s, %(tsnr2_lya_m11)s, %(tsnr2_bgs_m11)s, %(tsnr2_gpbdark_m11)s, %(tsnr2_gpbbright_m11)s, %(tsnr2_gpbbackup_m11)s, %(lrg_efftime_dark_m11)s, %(elg_efftime_dark_m11)s, %(bgs_efftime_bright_m11)s, %(lya_efftime_dark_m11)s, %(gpb_efftime_dark_m11)s, %(gpb_efftime_bright_m11)s, %(gpb_efftime_backup_m11)s, %(transparency_gfa_m11)s, %(seeing_gfa_m11)s, %(fiber_fracflux_gfa_m11)s, %(fiber_fracflux_elg_gfa_m11)s, %(fiber_fracflux_bgs_gfa_m11)s, %(fiberfac_gfa_m11)s, %(fiberfac_elg_gfa_m11)s, %(fiberfac_bgs_gfa_m11)s, %(airmass_gfa_m11)s, %(sky_mag_ab_gfa_m11)s, %(sky_mag_g_spec_m11)s, %(sky_mag_r_spec_m11)s, %(sky_mag_z_spec_m11)s, %(efftime_gfa_m11)s, %(efftime_dark_gfa_m11)s, %(efftime_bright_gfa_m11)s, %(efftime_backup_gfa_m11)s), (%(night_m12)s, %(expid_m12)s, %(tileid_m12)s, %(tilera_m12)s, %(tiledec_m12)s, %(date_obs_m12)s, %(mjd_m12)s, %(survey_m12)s, %(program_m12)s, %(faprgrm_m12)s, %(faflavor_m12)s, %(exptime_m12)s, %(efftime_spec_m12)s, %(goaltime_m12)s, %(goaltype_m12)s, %(mintfrac_m12)s, %(airmass_m12)s, %(ebv_m12)s, %(seeing_etc_m12)s, %(efftime_etc_m12)s, %(tsnr2_elg_m12)s, %(tsnr2_qso_m12)s, %(tsnr2_lrg_m12)s, %(tsnr2_lya_m12)s, %(tsnr2_bgs_m12)s, %(tsnr2_gpbdark_m12)s, %(tsnr2_gpbbright_m12)s, %(tsnr2_gpbbackup_m12)s, %(lrg_efftime_dark_m12)s, %(elg_efftime_dark_m12)s, %(bgs_efftime_bright_m12)s, %(lya_efftime_dark_m12)s, %(gpb_efftime_dark_m12)s, %(gpb_efftime_bright_m12)s, %(gpb_efftime_backup_m12)s, %(transparency_gfa_m12)s, %(seeing_gfa_m12)s, %(fiber_fracflux_gfa_m12)s, %(fiber_fracflux_elg_gfa_m12)s, %(fiber_fracflux_bgs_gfa_m12)s, %(fiberfac_gfa_m12)s, %(fiberfac_elg_gfa_m12)s, %(fiberfac_bgs_gfa_m12)s, %(airmass_gfa_m12)s, %(sky_mag_ab_gfa_m12)s, %(sky_mag_g_spec_m12)s, %(sky_mag_r_spec_m12)s, %(sky_mag_z_spec_m12)s, %(efftime_gfa_m12)s, %(efftime_dark_gfa_m12)s, %(efftime_bright_gfa_m12)s, %(efftime_backup_gfa_m12)s), (%(night_m13)s, %(expid_m13)s, %(tileid_m13)s, %(tilera_m13)s, %(tiledec_m13)s, %(date_obs_m13)s, %(mjd_m13)s, %(survey_m13)s, %(program_m13)s, %(faprgrm_m13)s, %(faflavor_m13)s, %(exptime_m13)s, %(efftime_spec_m13)s, %(goaltime_m13)s, %(goaltype_m13)s, %(mintfrac_m13)s, %(airmass_m13)s, %(ebv_m13)s, %(seeing_etc_m13)s, %(efftime_etc_m13)s, %(tsnr2_elg_m13)s, %(tsnr2_qso_m13)s, %(tsnr2_lrg_m13)s, %(tsnr2_lya_m13)s, %(tsnr2_bgs_m13)s, %(tsnr2_gpbdark_m13)s, %(tsnr2_gpbbright_m13)s, %(tsnr2_gpbbackup_m13)s, %(lrg_efftime_dark_m13)s, %(elg_efftime_dark_m13)s, %(bgs_efftime_bright_m13)s, %(lya_efftime_dark_m13)s, %(gpb_efftime_dark_m13)s, %(gpb_efftime_bright_m13)s, %(gpb_efftime_backup_m13)s, %(transparency_gfa_m13)s, %(seeing_gfa_m13)s, %(fiber_fracflux_gfa_m13)s, %(fiber_fracflux_elg_gfa_m13)s, %(fiber_fracflux_bgs_gfa_m13)s, %(fiberfac_gfa_m13)s, %(fiberfac_elg_gfa_m13)s, %(fiberfac_bgs_gfa_m13)s, %(airmass_gfa_m13)s, %(sky_mag_ab_gfa_m13)s, %(sky_mag_g_spec_m13)s, %(sky_mag_r_spec_m13)s, %(sky_mag_z_spec_m13)s, %(efftime_gfa_m13)s, %(efftime_dark_gfa_m13)s, %(efftime_bright_gfa_m13)s, %(efftime_backup_gfa_m13)s), (%(night_m14)s, %(expid_m14)s, %(tileid_m14)s, %(tilera_m14)s, %(tiledec_m14)s, %(date_obs_m14)s, %(mjd_m14)s, %(survey_m14)s, %(program_m14)s, %(faprgrm_m14)s, %(faflavor_m14)s, %(exptime_m14)s, %(efftime_spec_m14)s, %(goaltime_m14)s, %(goaltype_m14)s, %(mintfrac_m14)s, %(airmass_m14)s, %(ebv_m14)s, %(seeing_etc_m14)s, %(efftime_etc_m14)s, %(tsnr2_elg_m14)s, %(tsnr2_qso_m14)s, %(tsnr2_lrg_m14)s, %(tsnr2_lya_m14)s, %(tsnr2_bgs_m14)s, %(tsnr2_gpbdark_m14)s, %(tsnr2_gpbbright_m14)s, %(tsnr2_gpbbackup_m14)s, %(lrg_efftime_dark_m14)s, %(elg_efftime_dark_m14)s, %(bgs_efftime_bright_m14)s, %(lya_efftime_dark_m14)s, %(gpb_efftime_dark_m14)s, %(gpb_efftime_bright_m14)s, %(gpb_efftime_backup_m14)s, %(transparency_gfa_m14)s, %(seeing_gfa_m14)s, %(fiber_fracflux_gfa_m14)s, %(fiber_fracflux_elg_gfa_m14)s, %(fiber_fracflux_bgs_gfa_m14)s, %(fiberfac_gfa_m14)s, %(fiberfac_elg_gfa_m14)s, %(fiberfac_bgs_gfa_m14)s, %(airmass_gfa_m14)s, %(sky_mag_ab_gfa_m14)s, %(sky_mag_g_spec_m14)s, %(sky_mag_r_spec_m14)s, %(sky_mag_z_spec_m14)s, %(efftime_gfa_m14)s, %(efftime_dark_gfa_m14)s, %(efftime_bright_gfa_m14)s, %(efftime_backup_gfa_m14)s), (%(night_m15)s, %(expid_m15)s, %(tileid_m15)s, %(tilera_m15)s, %(tiledec_m15)s, %(date_obs_m15)s, %(mjd_m15)s, %(survey_m15)s, %(program_m15)s, %(faprgrm_m15)s, %(faflavor_m15)s, %(exptime_m15)s, %(efftime_spec_m15)s, %(goaltime_m15)s, %(goaltype_m15)s, %(mintfrac_m15)s, %(airmass_m15)s, %(ebv_m15)s, %(seeing_etc_m15)s, %(efftime_etc_m15)s, %(tsnr2_elg_m15)s, %(tsnr2_qso_m15)s, %(tsnr2_lrg_m15)s, %(tsnr2_lya_m15)s, %(tsnr2_bgs_m15)s, %(tsnr2_gpbdark_m15)s, %(tsnr2_gpbbright_m15)s, %(tsnr2_gpbbackup_m15)s, %(lrg_efftime_dark_m15)s, %(elg_efftime_dark_m15)s, %(bgs_efftime_bright_m15)s, %(lya_efftime_dark_m15)s, %(gpb_efftime_dark_m15)s, %(gpb_efftime_bright_m15)s, %(gpb_efftime_backup_m15)s, %(transparency_gfa_m15)s, %(seeing_gfa_m15)s, %(fiber_fracflux_gfa_m15)s, %(fiber_fracflux_elg_gfa_m15)s, %(fiber_fracflux_bgs_gfa_m15)s, %(fiberfac_gfa_m15)s, %(fiberfac_elg_gfa_m15)s, %(fiberfac_bgs_gfa_m15)s, %(airmass_gfa_m15)s, %(sky_mag_ab_gfa_m15)s, %(sky_mag_g_spec_m15)s, %(sky_mag_r_spec_m15)s, %(sky_mag_z_spec_m15)s, %(efftime_gfa_m15)s, %(efftime_dark_gfa_m15)s, %(efftime_bright_gfa_m15)s, %(efftime_backup_gfa_m15)s), (%(night_m16)s, %(expid_m16)s, %(tileid_m16)s, %(tilera_m16)s, %(tiledec_m16)s, %(date_obs_m16)s, %(mjd_m16)s, %(survey_m16)s, %(program_m16)s, %(faprgrm_m16)s, %(faflavor_m16)s, %(exptime_m16)s, %(efftime_spec_m16)s, %(goaltime_m16)s, %(goaltype_m16)s, %(mintfrac_m16)s, %(airmass_m16)s, %(ebv_m16)s, %(seeing_etc_m16)s, %(efftime_etc_m16)s, %(tsnr2_elg_m16)s, %(tsnr2_qso_m16)s, %(tsnr2_lrg_m16)s, %(tsnr2_lya_m16)s, %(tsnr2_bgs_m16)s, %(tsnr2_gpbdark_m16)s, %(tsnr2_gpbbright_m16)s, %(tsnr2_gpbbackup_m16)s, %(lrg_efftime_dark_m16)s, %(elg_efftime_dark_m16)s, %(bgs_efftime_bright_m16)s, %(lya_efftime_dark_m16)s, %(gpb_efftime_dark_m16)s, %(gpb_efftime_bright_m16)s, %(gpb_efftime_backup_m16)s, %(transparency_gfa_m16)s, %(seeing_gfa_m16)s, %(fiber_fracflux_gfa_m16)s, %(fiber_fracflux_elg_gfa_m16)s, %(fiber_fracflux_bgs_gfa_m16)s, %(fiberfac_gfa_m16)s, %(fiberfac_elg_gfa_m16)s, %(fiberfac_bgs_gfa_m16)s, %(airmass_gfa_m16)s, %(sky_mag_ab_gfa_m16)s, %(sky_mag_g_spec_m16)s, %(sky_mag_r_spec_m16)s, %(sky_mag_z_spec_m16)s, %(efftime_gfa_m16)s, %(efftime_dark_gfa_m16)s, %(efftime_bright_gfa_m16)s, %(efftime_backup_gfa_m16)s), (%(night_m17)s, %(expid_m17)s, %(tileid_m17)s, %(tilera_m17)s, %(tiledec_m17)s, %(date_obs_m17)s, %(mjd_m17)s, %(survey_m17)s, %(program_m17)s, %(faprgrm_m17)s, %(faflavor_m17)s, %(exptime_m17)s, %(efftime_spec_m17)s, %(goaltime_m17)s, %(goaltype_m17)s, %(mintfrac_m17)s, %(airmass_m17)s, %(ebv_m17)s, %(seeing_etc_m17)s, %(efftime_etc_m17)s, %(tsnr2_elg_m17)s, %(tsnr2_qso_m17)s, %(tsnr2_lrg_m17)s, %(tsnr2_lya_m17)s, %(tsnr2_bgs_m17)s, %(tsnr2_gpbdark_m17)s, %(tsnr2_gpbbright_m17)s, %(tsnr2_gpbbackup_m17)s, %(lrg_efftime_dark_m17)s, %(elg_efftime_dark_m17)s, %(bgs_efftime_bright_m17)s, %(lya_efftime_dark_m17)s, %(gpb_efftime_dark_m17)s, %(gpb_efftime_bright_m17)s, %(gpb_efftime_backup_m17)s, %(transparency_gfa_m17)s, %(seeing_gfa_m17)s, %(fiber_fracflux_gfa_m17)s, %(fiber_fracflux_elg_gfa_m17)s, %(fiber_fracflux_bgs_gfa_m17)s, %(fiberfac_gfa_m17)s, %(fiberfac_elg_gfa_m17)s, %(fiberfac_bgs_gfa_m17)s, %(airmass_gfa_m17)s, %(sky_mag_ab_gfa_m17)s, %(sky_mag_g_spec_m17)s, %(sky_mag_r_spec_m17)s, %(sky_mag_z_spec_m17)s, %(efftime_gfa_m17)s, %(efftime_dark_gfa_m17)s, %(efftime_bright_gfa_m17)s, %(efftime_backup_gfa_m17)s), (%(night_m18)s, %(expid_m18)s, %(tileid_m18)s, %(tilera_m18)s, %(tiledec_m18)s, %(date_obs_m18)s, %(mjd_m18)s, %(survey_m18)s, %(program_m18)s, %(faprgrm_m18)s, %(faflavor_m18)s, %(exptime_m18)s, %(efftime_spec_m18)s, %(goaltime_m18)s, %(goaltype_m18)s, %(mintfrac_m18)s, %(airmass_m18)s, %(ebv_m18)s, %(seeing_etc_m18)s, %(efftime_etc_m18)s, %(tsnr2_elg_m18)s, %(tsnr2_qso_m18)s, %(tsnr2_lrg_m18)s, %(tsnr2_lya_m18)s, %(tsnr2_bgs_m18)s, %(tsnr2_gpbdark_m18)s, %(tsnr2_gpbbright_m18)s, %(tsnr2_gpbbackup_m18)s, %(lrg_efftime_dark_m18)s, %(elg_efftime_dark_m18)s, %(bgs_efftime_bright_m18)s, %(lya_efftime_dark_m18)s, %(gpb_efftime_dark_m18)s, %(gpb_efftime_bright_m18)s, %(gpb_efftime_backup_m18)s, %(transparency_gfa_m18)s, %(seeing_gfa_m18)s, %(fiber_fracflux_gfa_m18)s, %(fiber_fracflux_elg_gfa_m18)s, %(fiber_fracflux_bgs_gfa_m18)s, %(fiberfac_gfa_m18)s, %(fiberfac_elg_gfa_m18)s, %(fiberfac_bgs_gfa_m18)s, %(airmass_gfa_m18)s, %(sky_mag_ab_gfa_m18)s, %(sky_mag_g_spec_m18)s, %(sky_mag_r_spec_m18)s, %(sky_mag_z_spec_m18)s, %(efftime_gfa_m18)s, %(efftime_dark_gfa_m18)s, %(efftime_bright_gfa_m18)s, %(efftime_backup_gfa_m18)s), (%(night_m19)s, %(expid_m19)s, %(tileid_m19)s, %(tilera_m19)s, %(tiledec_m19)s, %(date_obs_m19)s, %(mjd_m19)s, %(survey_m19)s, %(program_m19)s, %(faprgrm_m19)s, %(faflavor_m19)s, %(exptime_m19)s, %(efftime_spec_m19)s, %(goaltime_m19)s, %(goaltype_m19)s, %(mintfrac_m19)s, %(airmass_m19)s, %(ebv_m19)s, %(seeing_etc_m19)s, %(efftime_etc_m19)s, %(tsnr2_elg_m19)s, %(tsnr2_qso_m19)s, %(tsnr2_lrg_m19)s, %(tsnr2_lya_m19)s, %(tsnr2_bgs_m19)s, %(tsnr2_gpbdark_m19)s, %(tsnr2_gpbbright_m19)s, %(tsnr2_gpbbackup_m19)s, %(lrg_efftime_dark_m19)s, %(elg_efftime_dark_m19)s, %(bgs_efftime_bright_m19)s, %(lya_efftime_dark_m19)s, %(gpb_efftime_dark_m19)s, %(gpb_efftime_bright_m19)s, %(gpb_efftime_backup_m19)s, %(transparency_gfa_m19)s, %(seeing_gfa_m19)s, %(fiber_fracflux_gfa_m19)s, %(fiber_fracflux_elg_gfa_m19)s, %(fiber_fracflux_bgs_gfa_m19)s, %(fiberfac_gfa_m19)s, %(fiberfac_elg_gfa_m19)s, %(fiberfac_bgs_gfa_m19)s, %(airmass_gfa_m19)s, %(sky_mag_ab_gfa_m19)s, %(sky_mag_g_spec_m19)s, %(sky_mag_r_spec_m19)s, %(sky_mag_z_spec_m19)s, %(efftime_gfa_m19)s, %(efftime_dark_gfa_m19)s, %(efftime_bright_gfa_m19)s, %(efftime_backup_gfa_m19)s), (%(night_m20)s, %(expid_m20)s, %(tileid_m20)s, %(tilera_m20)s, %(tiledec_m20)s, %(date_obs_m20)s, %(mjd_m20)s, %(survey_m20)s, %(program_m20)s, %(faprgrm_m20)s, %(faflavor_m20)s, %(exptime_m20)s, %(efftime_spec_m20)s, %(goaltime_m20)s, %(goaltype_m20)s, %(mintfrac_m20)s, %(airmass_m20)s, %(ebv_m20)s, %(seeing_etc_m20)s, %(efftime_etc_m20)s, %(tsnr2_elg_m20)s, %(tsnr2_qso_m20)s, %(tsnr2_lrg_m20)s, %(tsnr2_lya_m20)s, %(tsnr2_bgs_m20)s, %(tsnr2_gpbdark_m20)s, %(tsnr2_gpbbright_m20)s, %(tsnr2_gpbbackup_m20)s, %(lrg_efftime_dark_m20)s, %(elg_efftime_dark_m20)s, %(bgs_efftime_bright_m20)s, %(lya_efftime_dark_m20)s, %(gpb_efftime_dark_m20)s, %(gpb_efftime_bright_m20)s, %(gpb_efftime_backup_m20)s, %(transparency_gfa_m20)s, %(seeing_gfa_m20)s, %(fiber_fracflux_gfa_m20)s, %(fiber_fracflux_elg_gfa_m20)s, %(fiber_fracflux_bgs_gfa_m20)s, %(fiberfac_gfa_m20)s, %(fiberfac_elg_gfa_m20)s, %(fiberfac_bgs_gfa_m20)s, %(airmass_gfa_m20)s, %(sky_mag_ab_gfa_m20)s, %(sky_mag_g_spec_m20)s, %(sky_mag_r_spec_m20)s, %(sky_mag_z_spec_m20)s, %(efftime_gfa_m20)s, %(efftime_dark_gfa_m20)s, %(efftime_bright_gfa_m20)s, %(efftime_backup_gfa_m20)s), (%(night_m21)s, %(expid_m21)s, %(tileid_m21)s, %(tilera_m21)s, %(tiledec_m21)s, %(date_obs_m21)s, %(mjd_m21)s, %(survey_m21)s, %(program_m21)s, %(faprgrm_m21)s, %(faflavor_m21)s, %(exptime_m21)s, %(efftime_spec_m21)s, %(goaltime_m21)s, %(goaltype_m21)s, %(mintfrac_m21)s, %(airmass_m21)s, %(ebv_m21)s, %(seeing_etc_m21)s, %(efftime_etc_m21)s, %(tsnr2_elg_m21)s, %(tsnr2_qso_m21)s, %(tsnr2_lrg_m21)s, %(tsnr2_lya_m21)s, %(tsnr2_bgs_m21)s, %(tsnr2_gpbdark_m21)s, %(tsnr2_gpbbright_m21)s, %(tsnr2_gpbbackup_m21)s, %(lrg_efftime_dark_m21)s, %(elg_efftime_dark_m21)s, %(bgs_efftime_bright_m21)s, %(lya_efftime_dark_m21)s, %(gpb_efftime_dark_m21)s, %(gpb_efftime_bright_m21)s, %(gpb_efftime_backup_m21)s, %(transparency_gfa_m21)s, %(seeing_gfa_m21)s, %(fiber_fracflux_gfa_m21)s, %(fiber_fracflux_elg_gfa_m21)s, %(fiber_fracflux_bgs_gfa_m21)s, %(fiberfac_gfa_m21)s, %(fiberfac_elg_gfa_m21)s, %(fiberfac_bgs_gfa_m21)s, %(airmass_gfa_m21)s, %(sky_mag_ab_gfa_m21)s, %(sky_mag_g_spec_m21)s, %(sky_mag_r_spec_m21)s, %(sky_mag_z_spec_m21)s, %(efftime_gfa_m21)s, %(efftime_dark_gfa_m21)s, %(efftime_bright_gfa_m21)s, %(efftime_backup_gfa_m21)s), (%(night_m22)s, %(expid_m22)s, %(tileid_m22)s, %(tilera_m22)s, %(tiledec_m22)s, %(date_obs_m22)s, %(mjd_m22)s, %(survey_m22)s, %(program_m22)s, %(faprgrm_m22)s, %(faflavor_m22)s, %(exptime_m22)s, %(efftime_spec_m22)s, %(goaltime_m22)s, %(goaltype_m22)s, %(mintfrac_m22)s, %(airmass_m22)s, %(ebv_m22)s, %(seeing_etc_m22)s, %(efftime_etc_m22)s, %(tsnr2_elg_m22)s, %(tsnr2_qso_m22)s, %(tsnr2_lrg_m22)s, %(tsnr2_lya_m22)s, %(tsnr2_bgs_m22)s, %(tsnr2_gpbdark_m22)s, %(tsnr2_gpbbright_m22)s, %(tsnr2_gpbbackup_m22)s, %(lrg_efftime_dark_m22)s, %(elg_efftime_dark_m22)s, %(bgs_efftime_bright_m22)s, %(lya_efftime_dark_m22)s, %(gpb_efftime_dark_m22)s, %(gpb_efftime_bright_m22)s, %(gpb_efftime_backup_m22)s, %(transparency_gfa_m22)s, %(seeing_gfa_m22)s, %(fiber_fracflux_gfa_m22)s, %(fiber_fracflux_elg_gfa_m22)s, %(fiber_fracflux_bgs_gfa_m22)s, %(fiberfac_gfa_m22)s, %(fiberfac_elg_gfa_m22)s, %(fiberfac_bgs_gfa_m22)s, %(airmass_gfa_m22)s, %(sky_mag_ab_gfa_m22)s, %(sky_mag_g_spec_m22)s, %(sky_mag_r_spec_m22)s, %(sky_mag_z_spec_m22)s, %(efftime_gfa_m22)s, %(efftime_dark_gfa_m22)s, %(efftime_bright_gfa_m22)s, %(efftime_backup_gfa_m22)s), (%(night_m23)s, %(expid_m23)s, %(tileid_m23)s, %(tilera_m23)s, %(tiledec_m23)s, %(date_obs_m23)s, %(mjd_m23)s, %(survey_m23)s, %(program_m23)s, %(faprgrm_m23)s, %(faflavor_m23)s, %(exptime_m23)s, %(efftime_spec_m23)s, %(goaltime_m23)s, %(goaltype_m23)s, %(mintfrac_m23)s, %(airmass_m23)s, %(ebv_m23)s, %(seeing_etc_m23)s, %(efftime_etc_m23)s, %(tsnr2_elg_m23)s, %(tsnr2_qso_m23)s, %(tsnr2_lrg_m23)s, %(tsnr2_lya_m23)s, %(tsnr2_bgs_m23)s, %(tsnr2_gpbdark_m23)s, %(tsnr2_gpbbright_m23)s, %(tsnr2_gpbbackup_m23)s, %(lrg_efftime_dark_m23)s, %(elg_efftime_dark_m23)s, %(bgs_efftime_bright_m23)s, %(lya_efftime_dark_m23)s, %(gpb_efftime_dark_m23)s, %(gpb_efftime_bright_m23)s, %(gpb_efftime_backup_m23)s, %(transparency_gfa_m23)s, %(seeing_gfa_m23)s, %(fiber_fracflux_gfa_m23)s, %(fiber_fracflux_elg_gfa_m23)s, %(fiber_fracflux_bgs_gfa_m23)s, %(fiberfac_gfa_m23)s, %(fiberfac_elg_gfa_m23)s, %(fiberfac_bgs_gfa_m23)s, %(airmass_gfa_m23)s, %(sky_mag_ab_gfa_m23)s, %(sky_mag_g_spec_m23)s, %(sky_mag_r_spec_m23)s, %(sky_mag_z_spec_m23)s, %(efftime_gfa_m23)s, %(efftime_dark_gfa_m23)s, %(efftime_bright_gfa_m23)s, %(efftime_backup_gfa_m23)s), (%(night_m24)s, %(expid_m24)s, %(tileid_m24)s, %(tilera_m24)s, %(tiledec_m24)s, %(date_obs_m24)s, %(mjd_m24)s, %(survey_m24)s, %(program_m24)s, %(faprgrm_m24)s, %(faflavor_m24)s, %(exptime_m24)s, %(efftime_spec_m24)s, %(goaltime_m24)s, %(goaltype_m24)s, %(mintfrac_m24)s, %(airmass_m24)s, %(ebv_m24)s, %(seeing_etc_m24)s, %(efftime_etc_m24)s, %(tsnr2_elg_m24)s, %(tsnr2_qso_m24)s, %(tsnr2_lrg_m24)s, %(tsnr2_lya_m24)s, %(tsnr2_bgs_m24)s, %(tsnr2_gpbdark_m24)s, %(tsnr2_gpbbright_m24)s, %(tsnr2_gpbbackup_m24)s, %(lrg_efftime_dark_m24)s, %(elg_efftime_dark_m24)s, %(bgs_efftime_bright_m24)s, %(lya_efftime_dark_m24)s, %(gpb_efftime_dark_m24)s, %(gpb_efftime_bright_m24)s, %(gpb_efftime_backup_m24)s, %(transparency_gfa_m24)s, %(seeing_gfa_m24)s, %(fiber_fracflux_gfa_m24)s, %(fiber_fracflux_elg_gfa_m24)s, %(fiber_fracflux_bgs_gfa_m24)s, %(fiberfac_gfa_m24)s, %(fiberfac_elg_gfa_m24)s, %(fiberfac_bgs_gfa_m24)s, %(airmass_gfa_m24)s, %(sky_mag_ab_gfa_m24)s, %(sky_mag_g_spec_m24)s, %(sky_mag_r_spec_m24)s, %(sky_mag_z_spec_m24)s, %(efftime_gfa_m24)s, %(efftime_dark_gfa_m24)s, %(efftime_bright_gfa_m24)s, %(efftime_backup_gfa_m24)s), (%(night_m25)s, %(expid_m25)s, %(tileid_m25)s, %(tilera_m25)s, %(tiledec_m25)s, %(date_obs_m25)s, %(mjd_m25)s, %(survey_m25)s, %(program_m25)s, %(faprgrm_m25)s, %(faflavor_m25)s, %(exptime_m25)s, %(efftime_spec_m25)s, %(goaltime_m25)s, %(goaltype_m25)s, %(mintfrac_m25)s, %(airmass_m25)s, %(ebv_m25)s, %(seeing_etc_m25)s, %(efftime_etc_m25)s, %(tsnr2_elg_m25)s, %(tsnr2_qso_m25)s, %(tsnr2_lrg_m25)s, %(tsnr2_lya_m25)s, %(tsnr2_bgs_m25)s, %(tsnr2_gpbdark_m25)s, %(tsnr2_gpbbright_m25)s, %(tsnr2_gpbbackup_m25)s, %(lrg_efftime_dark_m25)s, %(elg_efftime_dark_m25)s, %(bgs_efftime_bright_m25)s, %(lya_efftime_dark_m25)s, %(gpb_efftime_dark_m25)s, %(gpb_efftime_bright_m25)s, %(gpb_efftime_backup_m25)s, %(transparency_gfa_m25)s, %(seeing_gfa_m25)s, %(fiber_fracflux_gfa_m25)s, %(fiber_fracflux_elg_gfa_m25)s, %(fiber_fracflux_bgs_gfa_m25)s, %(fiberfac_gfa_m25)s, %(fiberfac_elg_gfa_m25)s, %(fiberfac_bgs_gfa_m25)s, %(airmass_gfa_m25)s, %(sky_mag_ab_gfa_m25)s, %(sky_mag_g_spec_m25)s, %(sky_mag_r_spec_m25)s, %(sky_mag_z_spec_m25)s, %(efftime_gfa_m25)s, %(efftime_dark_gfa_m25)s, %(efftime_bright_gfa_m25)s, %(efftime_backup_gfa_m25)s), (%(night_m26)s, %(expid_m26)s, %(tileid_m26)s, %(tilera_m26)s, %(tiledec_m26)s, %(date_obs_m26)s, %(mjd_m26)s, %(survey_m26)s, %(program_m26)s, %(faprgrm_m26)s, %(faflavor_m26)s, %(exptime_m26)s, %(efftime_spec_m26)s, %(goaltime_m26)s, %(goaltype_m26)s, %(mintfrac_m26)s, %(airmass_m26)s, %(ebv_m26)s, %(seeing_etc_m26)s, %(efftime_etc_m26)s, %(tsnr2_elg_m26)s, %(tsnr2_qso_m26)s, %(tsnr2_lrg_m26)s, %(tsnr2_lya_m26)s, %(tsnr2_bgs_m26)s, %(tsnr2_gpbdark_m26)s, %(tsnr2_gpbbright_m26)s, %(tsnr2_gpbbackup_m26)s, %(lrg_efftime_dark_m26)s, %(elg_efftime_dark_m26)s, %(bgs_efftime_bright_m26)s, %(lya_efftime_dark_m26)s, %(gpb_efftime_dark_m26)s, %(gpb_efftime_bright_m26)s, %(gpb_efftime_backup_m26)s, %(transparency_gfa_m26)s, %(seeing_gfa_m26)s, %(fiber_fracflux_gfa_m26)s, %(fiber_fracflux_elg_gfa_m26)s, %(fiber_fracflux_bgs_gfa_m26)s, %(fiberfac_gfa_m26)s, %(fiberfac_elg_gfa_m26)s, %(fiberfac_bgs_gfa_m26)s, %(airmass_gfa_m26)s, %(sky_mag_ab_gfa_m26)s, %(sky_mag_g_spec_m26)s, %(sky_mag_r_spec_m26)s, %(sky_mag_z_spec_m26)s, %(efftime_gfa_m26)s, %(efftime_dark_gfa_m26)s, %(efftime_bright_gfa_m26)s, %(efftime_backup_gfa_m26)s), (%(night_m27)s, %(expid_m27)s, %(tileid_m27)s, %(tilera_m27)s, %(tiledec_m27)s, %(date_obs_m27)s, %(mjd_m27)s, %(survey_m27)s, %(program_m27)s, %(faprgrm_m27)s, %(faflavor_m27)s, %(exptime_m27)s, %(efftime_spec_m27)s, %(goaltime_m27)s, %(goaltype_m27)s, %(mintfrac_m27)s, %(airmass_m27)s, %(ebv_m27)s, %(seeing_etc_m27)s, %(efftime_etc_m27)s, %(tsnr2_elg_m27)s, %(tsnr2_qso_m27)s, %(tsnr2_lrg_m27)s, %(tsnr2_lya_m27)s, %(tsnr2_bgs_m27)s, %(tsnr2_gpbdark_m27)s, %(tsnr2_gpbbright_m27)s, %(tsnr2_gpbbackup_m27)s, %(lrg_efftime_dark_m27)s, %(elg_efftime_dark_m27)s, %(bgs_efftime_bright_m27)s, %(lya_efftime_dark_m27)s, %(gpb_efftime_dark_m27)s, %(gpb_efftime_bright_m27)s, %(gpb_efftime_backup_m27)s, %(transparency_gfa_m27)s, %(seeing_gfa_m27)s, %(fiber_fracflux_gfa_m27)s, %(fiber_fracflux_elg_gfa_m27)s, %(fiber_fracflux_bgs_gfa_m27)s, %(fiberfac_gfa_m27)s, %(fiberfac_elg_gfa_m27)s, %(fiberfac_bgs_gfa_m27)s, %(airmass_gfa_m27)s, %(sky_mag_ab_gfa_m27)s, %(sky_mag_g_spec_m27)s, %(sky_mag_r_spec_m27)s, %(sky_mag_z_spec_m27)s, %(efftime_gfa_m27)s, %(efftime_dark_gfa_m27)s, %(efftime_bright_gfa_m27)s, %(efftime_backup_gfa_m27)s), (%(night_m28)s, %(expid_m28)s, %(tileid_m28)s, %(tilera_m28)s, %(tiledec_m28)s, %(date_obs_m28)s, %(mjd_m28)s, %(survey_m28)s, %(program_m28)s, %(faprgrm_m28)s, %(faflavor_m28)s, %(exptime_m28)s, %(efftime_spec_m28)s, %(goaltime_m28)s, %(goaltype_m28)s, %(mintfrac_m28)s, %(airmass_m28)s, %(ebv_m28)s, %(seeing_etc_m28)s, %(efftime_etc_m28)s, %(tsnr2_elg_m28)s, %(tsnr2_qso_m28)s, %(tsnr2_lrg_m28)s, %(tsnr2_lya_m28)s, %(tsnr2_bgs_m28)s, %(tsnr2_gpbdark_m28)s, %(tsnr2_gpbbright_m28)s, %(tsnr2_gpbbackup_m28)s, %(lrg_efftime_dark_m28)s, %(elg_efftime_dark_m28)s, %(bgs_efftime_bright_m28)s, %(lya_efftime_dark_m28)s, %(gpb_efftime_dark_m28)s, %(gpb_efftime_bright_m28)s, %(gpb_efftime_backup_m28)s, %(transparency_gfa_m28)s, %(seeing_gfa_m28)s, %(fiber_fracflux_gfa_m28)s, %(fiber_fracflux_elg_gfa_m28)s, %(fiber_fracflux_bgs_gfa_m28)s, %(fiberfac_gfa_m28)s, %(fiberfac_elg_gfa_m28)s, %(fiberfac_bgs_gfa_m28)s, %(airmass_gfa_m28)s, %(sky_mag_ab_gfa_m28)s, %(sky_mag_g_spec_m28)s, %(sky_mag_r_spec_m28)s, %(sky_mag_z_spec_m28)s, %(efftime_gfa_m28)s, %(efftime_dark_gfa_m28)s, %(efftime_bright_gfa_m28)s, %(efftime_backup_gfa_m28)s), (%(night_m29)s, %(expid_m29)s, %(tileid_m29)s, %(tilera_m29)s, %(tiledec_m29)s, %(date_obs_m29)s, %(mjd_m29)s, %(survey_m29)s, %(program_m29)s, %(faprgrm_m29)s, %(faflavor_m29)s, %(exptime_m29)s, %(efftime_spec_m29)s, %(goaltime_m29)s, %(goaltype_m29)s, %(mintfrac_m29)s, %(airmass_m29)s, %(ebv_m29)s, %(seeing_etc_m29)s, %(efftime_etc_m29)s, %(tsnr2_elg_m29)s, %(tsnr2_qso_m29)s, %(tsnr2_lrg_m29)s, %(tsnr2_lya_m29)s, %(tsnr2_bgs_m29)s, %(tsnr2_gpbdark_m29)s, %(tsnr2_gpbbright_m29)s, %(tsnr2_gpbbackup_m29)s, %(lrg_efftime_dark_m29)s, %(elg_efftime_dark_m29)s, %(bgs_efftime_bright_m29)s, %(lya_efftime_dark_m29)s, %(gpb_efftime_dark_m29)s, %(gpb_efftime_bright_m29)s, %(gpb_efftime_backup_m29)s, %(transparency_gfa_m29)s, %(seeing_gfa_m29)s, %(fiber_fracflux_gfa_m29)s, %(fiber_fracflux_elg_gfa_m29)s, %(fiber_fracflux_bgs_gfa_m29)s, %(fiberfac_gfa_m29)s, %(fiberfac_elg_gfa_m29)s, %(fiberfac_bgs_gfa_m29)s, %(airmass_gfa_m29)s, %(sky_mag_ab_gfa_m29)s, %(sky_mag_g_spec_m29)s, %(sky_mag_r_spec_m29)s, %(sky_mag_z_spec_m29)s, %(efftime_gfa_m29)s, %(efftime_dark_gfa_m29)s, %(efftime_bright_gfa_m29)s, %(efftime_backup_gfa_m29)s), (%(night_m30)s, %(expid_m30)s, %(tileid_m30)s, %(tilera_m30)s, %(tiledec_m30)s, %(date_obs_m30)s, %(mjd_m30)s, %(survey_m30)s, %(program_m30)s, %(faprgrm_m30)s, %(faflavor_m30)s, %(exptime_m30)s, %(efftime_spec_m30)s, %(goaltime_m30)s, %(goaltype_m30)s, %(mintfrac_m30)s, %(airmass_m30)s, %(ebv_m30)s, %(seeing_etc_m30)s, %(efftime_etc_m30)s, %(tsnr2_elg_m30)s, %(tsnr2_qso_m30)s, %(tsnr2_lrg_m30)s, %(tsnr2_lya_m30)s, %(tsnr2_bgs_m30)s, %(tsnr2_gpbdark_m30)s, %(tsnr2_gpbbright_m30)s, %(tsnr2_gpbbackup_m30)s, %(lrg_efftime_dark_m30)s, %(elg_efftime_dark_m30)s, %(bgs_efftime_bright_m30)s, %(lya_efftime_dark_m30)s, %(gpb_efftime_dark_m30)s, %(gpb_efftime_bright_m30)s, %(gpb_efftime_backup_m30)s, %(transparency_gfa_m30)s, %(seeing_gfa_m30)s, %(fiber_fracflux_gfa_m30)s, %(fiber_fracflux_elg_gfa_m30)s, %(fiber_fracflux_bgs_gfa_m30)s, %(fiberfac_gfa_m30)s, %(fiberfac_elg_gfa_m30)s, %(fiberfac_bgs_gfa_m30)s, %(airmass_gfa_m30)s, %(sky_mag_ab_gfa_m30)s, %(sky_mag_g_spec_m30)s, %(sky_mag_r_spec_m30)s, %(sky_mag_z_spec_m30)s, %(efftime_gfa_m30)s, %(efftime_dark_gfa_m30)s, %(efftime_bright_gfa_m30)s, %(efftime_backup_gfa_m30)s) ON CONFLICT (expid) DO UPDATE SET night = excluded.night, tileid = excluded.tileid, tilera = excluded.tilera, tiledec = excluded.tiledec, date_obs = excluded.date_obs, mjd = excluded.mjd, survey = excluded.survey, program = excluded.program, faprgrm = excluded.faprgrm, faflavor = excluded.faflavor, exptime = excluded.exptime, efftime_spec = excluded.efftime_spec, goaltime = excluded.goaltime, goaltype = excluded.goaltype, mintfrac = excluded.mintfrac, airmass = excluded.airmass, ebv = excluded.ebv, seeing_etc = excluded.seeing_etc, efftime_etc = excluded.efftime_etc, tsnr2_elg = excluded.tsnr2_elg, tsnr2_qso = excluded.tsnr2_qso, tsnr2_lrg = excluded.tsnr2_lrg, tsnr2_lya = excluded.tsnr2_lya, tsnr2_bgs = excluded.tsnr2_bgs, tsnr2_gpbdark = excluded.tsnr2_gpbdark, tsnr2_gpbbright = excluded.tsnr2_gpbbright, tsnr2_gpbbackup = excluded.tsnr2_gpbbackup, lrg_efftime_dark = excluded.lrg_efftime_dark, elg_efftime_dark = excluded.elg_efftime_dark, bgs_efftime_bright = excluded.bgs_efftime_bright, lya_efftime_dark = excluded.lya_efftime_dark, gpb_efftime_dark = excluded.gpb_efftime_dark, gpb_efftime_bright = excluded.gpb_efftime_bright, gpb_efftime_backup = excluded.gpb_efftime_backup, transparency_gfa = excluded.transparency_gfa, seeing_gfa = excluded.seeing_gfa, fiber_fracflux_gfa = excluded.fiber_fracflux_gfa, fiber_fracflux_elg_gfa = excluded.fiber_fracflux_elg_gfa, fiber_fracflux_bgs_gfa = excluded.fiber_fracflux_bgs_gfa, fiberfac_gfa = excluded.fiberfac_gfa, fiberfac_elg_gfa = excluded.fiberfac_elg_gfa, fiberfac_bgs_gfa = excluded.fiberfac_bgs_gfa, airmass_gfa = excluded.airmass_gfa, sky_mag_ab_gfa = excluded.sky_mag_ab_gfa, sky_mag_g_spec = excluded.sky_mag_g_spec, sky_mag_r_spec = excluded.sky_mag_r_spec, sky_mag_z_spec = excluded.sky_mag_z_spec, efftime_gfa = excluded.efftime_gfa, efftime_dark_gfa = excluded.efftime_dark_gfa, efftime_bright_gfa = excluded.efftime_bright_gfa, efftime_backup_gfa = excluded.efftime_backup_gfa\n"
+     ]
+    }
+   ],
+   "source": [
+    "stmt = upsert(load_exposures)\n",
+    "print(stmt)\n",
+    "db.dbSession.execute(stmt)\n",
+    "db.dbSession.commit()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 97,
+   "id": "7974d98d-dd93-492c-9cad-dcf0085a4b92",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "stmt = upsert(load_frames)\n",
+    "# db.dbSession.rollback()\n",
+    "# print(stmt)\n",
+    "db.dbSession.execute(stmt)\n",
+    "db.dbSession.commit()"
    ]
   },
   {
@@ -292,7 +843,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "f419c90d-1f45-46e4-add8-db81ed260a83",
    "metadata": {},
    "outputs": [],
@@ -302,7 +853,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "605895fe",
    "metadata": {},
    "outputs": [],
@@ -452,7 +1003,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "71a542f1",
    "metadata": {},
    "outputs": [],
@@ -553,14 +1104,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 98,
    "id": "b5db94c2-d3f4-41ab-a05a-f24c91f202b6",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "db.dbSession.close()\n",
     "db.engine.dispose()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88edba00-248e-4fe7-972a-b831a9ec1633",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/doc/nb/TestNewTile.ipynb
+++ b/doc/nb/TestNewTile.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "1bd0d356-77e9-4d62-a47f-b2f9ff00e898",
    "metadata": {
     "tags": []
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "2c1f6604-55f5-4f47-be69-ea9689544157",
    "metadata": {
     "tags": []
@@ -64,26 +64,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "e782a524-9168-4dcf-bdbf-01b05193382c",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:load.py:1508:setup_db: Begin creating tables.\n",
-      "INFO:load.py:1511:setup_db: Finished creating tables.\n",
-      "INFO:load.py:1411:load_versions: Loading version metadata.\n",
-      "INFO:load.py:1422:load_versions: Completed loading version metadata.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "os.environ['DESI_LOGLEVEL'] = 'DEBUG'\n",
-    "db.log = get_logger(DEBUG)\n",
+    "db.log = get_logger(DEBUG, timestamp=True)\n",
     "hostname = 'db2-loadbalancer.specprod.production.svc.spin.nersc.org'\n",
     "# hostname = 'localhost'\n",
     "postgresql = db.setup_db(schema=specprod, hostname=hostname, username='desi_admin', overwrite=overwrite)\n",
@@ -101,23 +90,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "065e77f2-cd38-4bf7-b9c1-319bc7707dd1",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DEBUG:meta.py:346:findfile: hpixdir = 'hpix'\n",
-      "DEBUG:meta.py:361:findfile: specprod_dir = '/global/cfs/cdirs/desi/spectro/redux/daily', specprod = 'None'\n",
-      "DEBUG:meta.py:375:findfile: Setting specprod = 'daily'\n",
-      "DEBUG:meta.py:32:get_desi_root_readonly: Using cached _desi_root_readonly=/dvs_ro/cfs/cdirs/desi\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "original_tiles_file = os.path.join(os.environ['DESI_ROOT'], 'users', os.environ['USER'], f'tiles-daily-patched-with-kibo-{tiles_patch_date}.csv')\n",
     "current_tiles_file = findfile('tiles', readonly=True)\n",
@@ -127,30 +105,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "35d5c59d-920b-4625-b1a7-c81d33f97512",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'/dvs_ro/cfs/cdirs/desi/spectro/redux/daily/tiles-daily.csv'"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "current_tiles_file"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "5322bcbd-8fcf-46a1-96be-2de812f7ea08",
    "metadata": {
     "tags": []
@@ -162,21 +129,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "0e3c5449-449d-4474-b570-7db3aa50d87d",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 696 ms, sys: 11.9 ms, total: 707 ms\n",
-      "Wall time: 706 ms\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "candidate_tiles = db.Tile.convert(tiles_table, row_index=row_index)"
@@ -194,23 +152,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "86c45810-11c1-4010-b429-1480f9d34008",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DEBUG:meta.py:346:findfile: hpixdir = 'hpix'\n",
-      "DEBUG:meta.py:361:findfile: specprod_dir = '/global/cfs/cdirs/desi/spectro/redux/daily', specprod = 'None'\n",
-      "DEBUG:meta.py:375:findfile: Setting specprod = 'daily'\n",
-      "DEBUG:meta.py:32:get_desi_root_readonly: Using cached _desi_root_readonly=/dvs_ro/cfs/cdirs/desi\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "original_exposures_file = os.path.join(os.environ['DESI_ROOT'], 'users', os.environ['USER'], f'exposures-daily-patched-with-kibo-{tiles_patch_date}.fits')\n",
     "current_exposures_file = findfile('exposures', readonly=True)\n",
@@ -221,21 +168,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "a8517a3d-0708-4b77-80b9-cab25554580b",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 30.6 s, sys: 206 ms, total: 30.8 s\n",
-      "Wall time: 30.9 s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "load_tiles = list()\n",
@@ -256,21 +194,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "38e20e0f-58e1-417d-b0ae-e902ac717888",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 3min 17s, sys: 1.13 s, total: 3min 18s\n",
-      "Wall time: 3min 18s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "load_frames = list()\n",
@@ -283,21 +212,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "8a509cfa-801c-4933-b550-b69ad75c337a",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 2.7 s, sys: 128 ms, total: 2.83 s\n",
-      "Wall time: 3.52 s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "try:\n",
@@ -310,21 +230,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "269a600d-2346-4300-b71d-a6aa4053b0d9",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 3.66 s, sys: 104 ms, total: 3.77 s\n",
-      "Wall time: 7.39 s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "try:\n",
@@ -337,21 +248,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "98306e39-48fd-41bc-9161-cbe1e47c28b6",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 47.3 s, sys: 972 ms, total: 48.2 s\n",
-      "Wall time: 1min 13s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "try:\n",
@@ -378,7 +280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "3ca0e31d-7833-40e1-b62f-c5bf2d9bcbaa",
    "metadata": {
     "tags": []
@@ -392,7 +294,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "0b03f183-f833-440a-9fca-6e7fa6e0d9e8",
    "metadata": {
     "tags": []
@@ -405,7 +307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "a09119c2-2af7-46cd-9cc5-a8b3291b946d",
    "metadata": {
     "tags": []
@@ -417,75 +319,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "id": "d7fc779b-82ec-45d5-8368-9ad62364719b",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><i>Table length=26</i>\n",
-       "<table id=\"table140306113489520\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>TILEID</th><th>SURVEY</th><th>PROGRAM</th><th>FAPRGRM</th><th>FAFLAVOR</th><th>NEXP</th><th>EXPTIME</th><th>TILERA</th><th>TILEDEC</th><th>EFFTIME_ETC</th><th>EFFTIME_SPEC</th><th>EFFTIME_GFA</th><th>GOALTIME</th><th>OBSSTATUS</th><th>LRG_EFFTIME_DARK</th><th>ELG_EFFTIME_DARK</th><th>BGS_EFFTIME_BRIGHT</th><th>LYA_EFFTIME_DARK</th><th>GOALTYPE</th><th>MINTFRAC</th><th>LASTNIGHT</th><th>UPDATED</th></tr></thead>\n",
-       "<thead><tr><th>int64</th><th>bytes20</th><th>bytes6</th><th>bytes20</th><th>bytes20</th><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>bytes20</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>bytes20</th><th>float64</th><th>int64</th><th>bytes24</th></tr></thead>\n",
-       "<tr><td>6498</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>949.7</td><td>20.467</td><td>28.44</td><td>1013.4</td><td>1019.5</td><td>1050.2</td><td>1000.0</td><td>obsend</td><td>1019.5</td><td>1078.6</td><td>983.0</td><td>1354.0</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
-       "<tr><td>8122</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1646.5</td><td>331.757</td><td>-13.178</td><td>1006.0</td><td>1122.4</td><td>1153.2</td><td>1000.0</td><td>obsend</td><td>1122.4</td><td>1122.3</td><td>1134.1</td><td>1648.2</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
-       "<tr><td>6757</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>865.6</td><td>2.874</td><td>27.131</td><td>1008.7</td><td>968.6</td><td>1079.3</td><td>1000.0</td><td>obsend</td><td>968.6</td><td>989.3</td><td>951.2</td><td>1410.0</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
-       "<tr><td>6501</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1084.4</td><td>28.043</td><td>28.166</td><td>1009.9</td><td>1032.8</td><td>1052.0</td><td>1000.0</td><td>obsend</td><td>1032.8</td><td>1076.8</td><td>1006.2</td><td>1395.9</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
-       "<tr><td>6225</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1487.1</td><td>336.749</td><td>-12.178</td><td>1006.3</td><td>1105.7</td><td>1098.3</td><td>1000.0</td><td>obsend</td><td>1105.7</td><td>1114.0</td><td>1108.5</td><td>1551.7</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
-       "<tr><td>1518</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1439.5</td><td>347.602</td><td>-12.842</td><td>1009.4</td><td>1051.2</td><td>1077.8</td><td>1000.0</td><td>obsend</td><td>1051.2</td><td>1055.7</td><td>1063.2</td><td>1506.5</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
-       "<tr><td>2471</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1330.3</td><td>37.973</td><td>-17.363</td><td>1002.7</td><td>1075.4</td><td>1021.0</td><td>1000.0</td><td>obsend</td><td>1075.4</td><td>1087.1</td><td>1081.5</td><td>1533.5</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
-       "<tr><td>1867</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1648.9</td><td>327.328</td><td>-10.39</td><td>1004.7</td><td>1117.2</td><td>1112.6</td><td>1000.0</td><td>obsend</td><td>1117.2</td><td>1128.8</td><td>1124.2</td><td>1598.3</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
-       "<tr><td>1804</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1078.6</td><td>30.674</td><td>25.605</td><td>1004.0</td><td>1065.7</td><td>1048.9</td><td>1000.0</td><td>obsend</td><td>1065.7</td><td>1129.3</td><td>1020.2</td><td>1284.4</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
-       "<tr><td>1549</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1421.0</td><td>354.576</td><td>-13.541</td><td>1007.8</td><td>1011.6</td><td>1110.7</td><td>1000.0</td><td>obsend</td><td>1011.6</td><td>1004.5</td><td>1025.6</td><td>1446.9</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
-       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
-       "<tr><td>8725</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1386.8</td><td>46.002</td><td>-15.237</td><td>1008.0</td><td>1097.0</td><td>1121.7</td><td>1000.0</td><td>obsend</td><td>1097.0</td><td>1116.5</td><td>1088.4</td><td>1475.6</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
-       "<tr><td>8732</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1666.4</td><td>43.883</td><td>-17.885</td><td>1007.4</td><td>1060.9</td><td>1071.1</td><td>1000.0</td><td>obsend</td><td>1060.9</td><td>1089.1</td><td>1069.0</td><td>1402.3</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
-       "<tr><td>9745</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1377.8</td><td>121.305</td><td>48.902</td><td>1007.1</td><td>1096.9</td><td>1053.0</td><td>1000.0</td><td>obsend</td><td>1096.9</td><td>1131.8</td><td>1085.7</td><td>1419.2</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
-       "<tr><td>9763</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1482.4</td><td>119.642</td><td>54.77</td><td>1011.2</td><td>1166.9</td><td>1132.8</td><td>1000.0</td><td>obsend</td><td>1166.9</td><td>1153.0</td><td>1157.6</td><td>1652.3</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
-       "<tr><td>11376</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1059.4</td><td>30.769</td><td>19.704</td><td>1007.5</td><td>987.9</td><td>1196.8</td><td>1000.0</td><td>obsend</td><td>987.9</td><td>1059.9</td><td>947.7</td><td>1253.9</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
-       "<tr><td>20973</td><td>main</td><td>bright</td><td>bright</td><td>mainbright</td><td>1</td><td>405.9</td><td>130.595</td><td>40.986</td><td>35.2</td><td>38.7</td><td>42.5</td><td>180.0</td><td>obsstart</td><td>32.4</td><td>38.6</td><td>38.7</td><td>49.5</td><td>bright</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
-       "<tr><td>27138</td><td>main</td><td>bright</td><td>bright</td><td>mainbright</td><td>1</td><td>884.9</td><td>334.949</td><td>-4.464</td><td>182.8</td><td>247.5</td><td>234.2</td><td>180.0</td><td>obsend</td><td>241.2</td><td>244.2</td><td>247.5</td><td>174.7</td><td>bright</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
-       "<tr><td>1516</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>1530.1</td><td>344.211</td><td>-12.42</td><td>1007.0</td><td>1074.2</td><td>1124.7</td><td>1000.0</td><td>obsend</td><td>1074.2</td><td>1074.6</td><td>1085.2</td><td>1536.0</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
-       "<tr><td>27152</td><td>main</td><td>bright</td><td>bright</td><td>mainbright</td><td>1</td><td>1220.1</td><td>318.789</td><td>-4.707</td><td>181.2</td><td>242.3</td><td>168.1</td><td>180.0</td><td>obsend</td><td>232.0</td><td>238.2</td><td>242.3</td><td>165.8</td><td>bright</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
-       "<tr><td>8264</td><td>main</td><td>dark</td><td>dark</td><td>maindark</td><td>1</td><td>804.6</td><td>7.047</td><td>27.959</td><td>1011.2</td><td>883.3</td><td>1064.4</td><td>1000.0</td><td>obsend</td><td>883.3</td><td>897.2</td><td>850.4</td><td>1460.9</td><td>dark</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
-       "</table></div>"
-      ],
-      "text/plain": [
-       "<Table length=26>\n",
-       "TILEID  SURVEY PROGRAM FAPRGRM ... MINTFRAC LASTNIGHT         UPDATED         \n",
-       "int64  bytes20  bytes6 bytes20 ... float64    int64           bytes24         \n",
-       "------ ------- ------- ------- ... -------- --------- ------------------------\n",
-       "  6498    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
-       "  8122    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
-       "  6757    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
-       "  6501    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
-       "  6225    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
-       "  1518    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
-       "  2471    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
-       "  1867    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
-       "  1804    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
-       "  1549    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
-       "   ...     ...     ...     ... ...      ...       ...                      ...\n",
-       "  8725    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
-       "  8732    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
-       "  9745    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
-       "  9763    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
-       " 11376    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
-       " 20973    main  bright  bright ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
-       " 27138    main  bright  bright ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
-       "  1516    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
-       " 27152    main  bright  bright ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
-       "  8264    main    dark    dark ...     0.85  20241007 2024-10-08T21:31:03-0700"
-      ]
-     },
-     "execution_count": 32,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "cached_tiles = np.array(list(map(int, tiles_cache.keys())))\n",
     "new_tiles = ~np.in1d(update_tiles_table['TILEID'], cached_tiles)\n",
@@ -506,44 +345,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "id": "444c8365-eb29-428e-ab7f-5b3aa3fc2b88",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><i>Table length=2</i>\n",
-       "<table id=\"table140305694153968\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>TILEID</th><th>SURVEY</th><th>PROGRAM</th><th>FAPRGRM</th><th>FAFLAVOR</th><th>NEXP</th><th>EXPTIME</th><th>TILERA</th><th>TILEDEC</th><th>EFFTIME_ETC</th><th>EFFTIME_SPEC</th><th>EFFTIME_GFA</th><th>GOALTIME</th><th>OBSSTATUS</th><th>LRG_EFFTIME_DARK</th><th>ELG_EFFTIME_DARK</th><th>BGS_EFFTIME_BRIGHT</th><th>LYA_EFFTIME_DARK</th><th>GOALTYPE</th><th>MINTFRAC</th><th>LASTNIGHT</th><th>UPDATED</th></tr></thead>\n",
-       "<thead><tr><th>int64</th><th>bytes20</th><th>bytes6</th><th>bytes20</th><th>bytes20</th><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>bytes20</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>bytes20</th><th>float64</th><th>int64</th><th>bytes24</th></tr></thead>\n",
-       "<tr><td>22957</td><td>main</td><td>bright</td><td>bright</td><td>mainbright</td><td>3</td><td>1065.7</td><td>128.532</td><td>30.959</td><td>192.7</td><td>180.0</td><td>214.5</td><td>180.0</td><td>obsend</td><td>157.4</td><td>172.7</td><td>180.0</td><td>206.2</td><td>bright</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
-       "<tr><td>27443</td><td>main</td><td>bright</td><td>bright</td><td>mainbright</td><td>2</td><td>964.4</td><td>115.927</td><td>28.387</td><td>157.4</td><td>184.0</td><td>192.1</td><td>180.0</td><td>obsend</td><td>167.5</td><td>196.2</td><td>184.0</td><td>188.4</td><td>bright</td><td>0.85</td><td>20241007</td><td>2024-10-08T21:31:03-0700</td></tr>\n",
-       "</table></div>"
-      ],
-      "text/plain": [
-       "<Table length=2>\n",
-       "TILEID  SURVEY PROGRAM FAPRGRM ... MINTFRAC LASTNIGHT         UPDATED         \n",
-       "int64  bytes20  bytes6 bytes20 ... float64    int64           bytes24         \n",
-       "------ ------- ------- ------- ... -------- --------- ------------------------\n",
-       " 22957    main  bright  bright ...     0.85  20241007 2024-10-08T21:31:03-0700\n",
-       " 27443    main  bright  bright ...     0.85  20241007 2024-10-08T21:31:03-0700"
-      ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "update_tiles_table[updated_tiles]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "id": "157947d9-d1d5-42fd-8984-9ceb407c06ad",
    "metadata": {
     "tags": []
@@ -564,7 +378,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "id": "d45408e3-2982-4e60-941c-da1d034fb36b",
    "metadata": {
     "tags": []
@@ -577,81 +391,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "id": "ebe3108f-438b-427f-ac8d-0e58020c6d39",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "([Tile(tileid=6498),\n",
-       "  Tile(tileid=8122),\n",
-       "  Tile(tileid=6757),\n",
-       "  Tile(tileid=6501),\n",
-       "  Tile(tileid=6225),\n",
-       "  Tile(tileid=1518),\n",
-       "  Tile(tileid=2471),\n",
-       "  Tile(tileid=1867),\n",
-       "  Tile(tileid=1804),\n",
-       "  Tile(tileid=1549),\n",
-       "  Tile(tileid=8259),\n",
-       "  Tile(tileid=5381),\n",
-       "  Tile(tileid=8261),\n",
-       "  Tile(tileid=9123),\n",
-       "  Tile(tileid=8495),\n",
-       "  Tile(tileid=8496),\n",
-       "  Tile(tileid=8725),\n",
-       "  Tile(tileid=8732),\n",
-       "  Tile(tileid=9745),\n",
-       "  Tile(tileid=9763),\n",
-       "  Tile(tileid=11376),\n",
-       "  Tile(tileid=20973),\n",
-       "  Tile(tileid=27138),\n",
-       "  Tile(tileid=1516),\n",
-       "  Tile(tileid=27152),\n",
-       "  Tile(tileid=8264),\n",
-       "  Tile(tileid=22957),\n",
-       "  Tile(tileid=27443)],\n",
-       " [Exposure(night=20241007, expid=256820, tileid=6498),\n",
-       "  Exposure(night=20241007, expid=256808, tileid=8122),\n",
-       "  Exposure(night=20241007, expid=256816, tileid=6757),\n",
-       "  Exposure(night=20241007, expid=256823, tileid=6501),\n",
-       "  Exposure(night=20241007, expid=256809, tileid=6225),\n",
-       "  Exposure(night=20241007, expid=256811, tileid=1518),\n",
-       "  Exposure(night=20241007, expid=256824, tileid=2471),\n",
-       "  Exposure(night=20241007, expid=256807, tileid=1867),\n",
-       "  Exposure(night=20241007, expid=256822, tileid=1804),\n",
-       "  Exposure(night=20241007, expid=256812, tileid=1549),\n",
-       "  Exposure(night=20241007, expid=256819, tileid=8259),\n",
-       "  Exposure(night=20241007, expid=256813, tileid=5381),\n",
-       "  Exposure(night=20241007, expid=256818, tileid=8261),\n",
-       "  Exposure(night=20241007, expid=256805, tileid=9123),\n",
-       "  Exposure(night=20241007, expid=256806, tileid=9123),\n",
-       "  Exposure(night=20241007, expid=256814, tileid=8495),\n",
-       "  Exposure(night=20241007, expid=256815, tileid=8496),\n",
-       "  Exposure(night=20241007, expid=256825, tileid=8725),\n",
-       "  Exposure(night=20241007, expid=256826, tileid=8732),\n",
-       "  Exposure(night=20241007, expid=256828, tileid=9745),\n",
-       "  Exposure(night=20241007, expid=256827, tileid=9763),\n",
-       "  Exposure(night=20241007, expid=256821, tileid=11376),\n",
-       "  Exposure(night=20241007, expid=256831, tileid=20973),\n",
-       "  Exposure(night=20241007, expid=256804, tileid=27138),\n",
-       "  Exposure(night=20241007, expid=256810, tileid=1516),\n",
-       "  Exposure(night=20241007, expid=256803, tileid=27152),\n",
-       "  Exposure(night=20241007, expid=256817, tileid=8264),\n",
-       "  Exposure(night=20241006, expid=256674, tileid=22957),\n",
-       "  Exposure(night=20241007, expid=256829, tileid=22957),\n",
-       "  Exposure(night=20240921, expid=254400, tileid=27443),\n",
-       "  Exposure(night=20241007, expid=256830, tileid=27443)])"
-      ]
-     },
-     "execution_count": 37,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "load_tiles = list()\n",
     "load_exposures = list()\n",
@@ -665,12 +410,15 @@
     "        bad_index = np.where((update_exposures_table['TILEID'] == new_tile.tileid))[0]\n",
     "        print(update_exposures_table[['EXPID', 'NIGHT', 'MJD', 'EFFTIME_SPEC']][bad_index])\n",
     "        # bad_tiles.append(new_tile)\n",
-    "# load_tiles, load_exposures"
+    "# load_tiles, load_exposures\n",
+    "\n",
+    "# Tiles that *change* to EFFTIME_SPEC = 0 should be removed as in DELETE.\n",
+    "# Keep the database in a state \"as if\" it had just been reloaded from scratch."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": null,
    "id": "b6e94fce-08bc-4361-bdf2-0ba6c7f2aab4",
    "metadata": {
     "tags": []
@@ -686,7 +434,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": null,
    "id": "1f0d8062-740f-46a4-8eb0-fc93cb4b5c35",
    "metadata": {
     "tags": []
@@ -701,30 +449,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": null,
    "id": "12ba3979-e2fb-4119-a79a-f7d6e413952a",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INSERT INTO daily.exposure (night, expid, tileid, tilera, tiledec, date_obs, mjd, survey, program, faprgrm, faflavor, exptime, efftime_spec, goaltime, goaltype, mintfrac, airmass, ebv, seeing_etc, efftime_etc, tsnr2_elg, tsnr2_qso, tsnr2_lrg, tsnr2_lya, tsnr2_bgs, tsnr2_gpbdark, tsnr2_gpbbright, tsnr2_gpbbackup, lrg_efftime_dark, elg_efftime_dark, bgs_efftime_bright, lya_efftime_dark, gpb_efftime_dark, gpb_efftime_bright, gpb_efftime_backup, transparency_gfa, seeing_gfa, fiber_fracflux_gfa, fiber_fracflux_elg_gfa, fiber_fracflux_bgs_gfa, fiberfac_gfa, fiberfac_elg_gfa, fiberfac_bgs_gfa, airmass_gfa, sky_mag_ab_gfa, sky_mag_g_spec, sky_mag_r_spec, sky_mag_z_spec, efftime_gfa, efftime_dark_gfa, efftime_bright_gfa, efftime_backup_gfa) VALUES (%(night_m0)s, %(expid_m0)s, %(tileid_m0)s, %(tilera_m0)s, %(tiledec_m0)s, %(date_obs_m0)s, %(mjd_m0)s, %(survey_m0)s, %(program_m0)s, %(faprgrm_m0)s, %(faflavor_m0)s, %(exptime_m0)s, %(efftime_spec_m0)s, %(goaltime_m0)s, %(goaltype_m0)s, %(mintfrac_m0)s, %(airmass_m0)s, %(ebv_m0)s, %(seeing_etc_m0)s, %(efftime_etc_m0)s, %(tsnr2_elg_m0)s, %(tsnr2_qso_m0)s, %(tsnr2_lrg_m0)s, %(tsnr2_lya_m0)s, %(tsnr2_bgs_m0)s, %(tsnr2_gpbdark_m0)s, %(tsnr2_gpbbright_m0)s, %(tsnr2_gpbbackup_m0)s, %(lrg_efftime_dark_m0)s, %(elg_efftime_dark_m0)s, %(bgs_efftime_bright_m0)s, %(lya_efftime_dark_m0)s, %(gpb_efftime_dark_m0)s, %(gpb_efftime_bright_m0)s, %(gpb_efftime_backup_m0)s, %(transparency_gfa_m0)s, %(seeing_gfa_m0)s, %(fiber_fracflux_gfa_m0)s, %(fiber_fracflux_elg_gfa_m0)s, %(fiber_fracflux_bgs_gfa_m0)s, %(fiberfac_gfa_m0)s, %(fiberfac_elg_gfa_m0)s, %(fiberfac_bgs_gfa_m0)s, %(airmass_gfa_m0)s, %(sky_mag_ab_gfa_m0)s, %(sky_mag_g_spec_m0)s, %(sky_mag_r_spec_m0)s, %(sky_mag_z_spec_m0)s, %(efftime_gfa_m0)s, %(efftime_dark_gfa_m0)s, %(efftime_bright_gfa_m0)s, %(efftime_backup_gfa_m0)s), (%(night_m1)s, %(expid_m1)s, %(tileid_m1)s, %(tilera_m1)s, %(tiledec_m1)s, %(date_obs_m1)s, %(mjd_m1)s, %(survey_m1)s, %(program_m1)s, %(faprgrm_m1)s, %(faflavor_m1)s, %(exptime_m1)s, %(efftime_spec_m1)s, %(goaltime_m1)s, %(goaltype_m1)s, %(mintfrac_m1)s, %(airmass_m1)s, %(ebv_m1)s, %(seeing_etc_m1)s, %(efftime_etc_m1)s, %(tsnr2_elg_m1)s, %(tsnr2_qso_m1)s, %(tsnr2_lrg_m1)s, %(tsnr2_lya_m1)s, %(tsnr2_bgs_m1)s, %(tsnr2_gpbdark_m1)s, %(tsnr2_gpbbright_m1)s, %(tsnr2_gpbbackup_m1)s, %(lrg_efftime_dark_m1)s, %(elg_efftime_dark_m1)s, %(bgs_efftime_bright_m1)s, %(lya_efftime_dark_m1)s, %(gpb_efftime_dark_m1)s, %(gpb_efftime_bright_m1)s, %(gpb_efftime_backup_m1)s, %(transparency_gfa_m1)s, %(seeing_gfa_m1)s, %(fiber_fracflux_gfa_m1)s, %(fiber_fracflux_elg_gfa_m1)s, %(fiber_fracflux_bgs_gfa_m1)s, %(fiberfac_gfa_m1)s, %(fiberfac_elg_gfa_m1)s, %(fiberfac_bgs_gfa_m1)s, %(airmass_gfa_m1)s, %(sky_mag_ab_gfa_m1)s, %(sky_mag_g_spec_m1)s, %(sky_mag_r_spec_m1)s, %(sky_mag_z_spec_m1)s, %(efftime_gfa_m1)s, %(efftime_dark_gfa_m1)s, %(efftime_bright_gfa_m1)s, %(efftime_backup_gfa_m1)s), (%(night_m2)s, %(expid_m2)s, %(tileid_m2)s, %(tilera_m2)s, %(tiledec_m2)s, %(date_obs_m2)s, %(mjd_m2)s, %(survey_m2)s, %(program_m2)s, %(faprgrm_m2)s, %(faflavor_m2)s, %(exptime_m2)s, %(efftime_spec_m2)s, %(goaltime_m2)s, %(goaltype_m2)s, %(mintfrac_m2)s, %(airmass_m2)s, %(ebv_m2)s, %(seeing_etc_m2)s, %(efftime_etc_m2)s, %(tsnr2_elg_m2)s, %(tsnr2_qso_m2)s, %(tsnr2_lrg_m2)s, %(tsnr2_lya_m2)s, %(tsnr2_bgs_m2)s, %(tsnr2_gpbdark_m2)s, %(tsnr2_gpbbright_m2)s, %(tsnr2_gpbbackup_m2)s, %(lrg_efftime_dark_m2)s, %(elg_efftime_dark_m2)s, %(bgs_efftime_bright_m2)s, %(lya_efftime_dark_m2)s, %(gpb_efftime_dark_m2)s, %(gpb_efftime_bright_m2)s, %(gpb_efftime_backup_m2)s, %(transparency_gfa_m2)s, %(seeing_gfa_m2)s, %(fiber_fracflux_gfa_m2)s, %(fiber_fracflux_elg_gfa_m2)s, %(fiber_fracflux_bgs_gfa_m2)s, %(fiberfac_gfa_m2)s, %(fiberfac_elg_gfa_m2)s, %(fiberfac_bgs_gfa_m2)s, %(airmass_gfa_m2)s, %(sky_mag_ab_gfa_m2)s, %(sky_mag_g_spec_m2)s, %(sky_mag_r_spec_m2)s, %(sky_mag_z_spec_m2)s, %(efftime_gfa_m2)s, %(efftime_dark_gfa_m2)s, %(efftime_bright_gfa_m2)s, %(efftime_backup_gfa_m2)s), (%(night_m3)s, %(expid_m3)s, %(tileid_m3)s, %(tilera_m3)s, %(tiledec_m3)s, %(date_obs_m3)s, %(mjd_m3)s, %(survey_m3)s, %(program_m3)s, %(faprgrm_m3)s, %(faflavor_m3)s, %(exptime_m3)s, %(efftime_spec_m3)s, %(goaltime_m3)s, %(goaltype_m3)s, %(mintfrac_m3)s, %(airmass_m3)s, %(ebv_m3)s, %(seeing_etc_m3)s, %(efftime_etc_m3)s, %(tsnr2_elg_m3)s, %(tsnr2_qso_m3)s, %(tsnr2_lrg_m3)s, %(tsnr2_lya_m3)s, %(tsnr2_bgs_m3)s, %(tsnr2_gpbdark_m3)s, %(tsnr2_gpbbright_m3)s, %(tsnr2_gpbbackup_m3)s, %(lrg_efftime_dark_m3)s, %(elg_efftime_dark_m3)s, %(bgs_efftime_bright_m3)s, %(lya_efftime_dark_m3)s, %(gpb_efftime_dark_m3)s, %(gpb_efftime_bright_m3)s, %(gpb_efftime_backup_m3)s, %(transparency_gfa_m3)s, %(seeing_gfa_m3)s, %(fiber_fracflux_gfa_m3)s, %(fiber_fracflux_elg_gfa_m3)s, %(fiber_fracflux_bgs_gfa_m3)s, %(fiberfac_gfa_m3)s, %(fiberfac_elg_gfa_m3)s, %(fiberfac_bgs_gfa_m3)s, %(airmass_gfa_m3)s, %(sky_mag_ab_gfa_m3)s, %(sky_mag_g_spec_m3)s, %(sky_mag_r_spec_m3)s, %(sky_mag_z_spec_m3)s, %(efftime_gfa_m3)s, %(efftime_dark_gfa_m3)s, %(efftime_bright_gfa_m3)s, %(efftime_backup_gfa_m3)s), (%(night_m4)s, %(expid_m4)s, %(tileid_m4)s, %(tilera_m4)s, %(tiledec_m4)s, %(date_obs_m4)s, %(mjd_m4)s, %(survey_m4)s, %(program_m4)s, %(faprgrm_m4)s, %(faflavor_m4)s, %(exptime_m4)s, %(efftime_spec_m4)s, %(goaltime_m4)s, %(goaltype_m4)s, %(mintfrac_m4)s, %(airmass_m4)s, %(ebv_m4)s, %(seeing_etc_m4)s, %(efftime_etc_m4)s, %(tsnr2_elg_m4)s, %(tsnr2_qso_m4)s, %(tsnr2_lrg_m4)s, %(tsnr2_lya_m4)s, %(tsnr2_bgs_m4)s, %(tsnr2_gpbdark_m4)s, %(tsnr2_gpbbright_m4)s, %(tsnr2_gpbbackup_m4)s, %(lrg_efftime_dark_m4)s, %(elg_efftime_dark_m4)s, %(bgs_efftime_bright_m4)s, %(lya_efftime_dark_m4)s, %(gpb_efftime_dark_m4)s, %(gpb_efftime_bright_m4)s, %(gpb_efftime_backup_m4)s, %(transparency_gfa_m4)s, %(seeing_gfa_m4)s, %(fiber_fracflux_gfa_m4)s, %(fiber_fracflux_elg_gfa_m4)s, %(fiber_fracflux_bgs_gfa_m4)s, %(fiberfac_gfa_m4)s, %(fiberfac_elg_gfa_m4)s, %(fiberfac_bgs_gfa_m4)s, %(airmass_gfa_m4)s, %(sky_mag_ab_gfa_m4)s, %(sky_mag_g_spec_m4)s, %(sky_mag_r_spec_m4)s, %(sky_mag_z_spec_m4)s, %(efftime_gfa_m4)s, %(efftime_dark_gfa_m4)s, %(efftime_bright_gfa_m4)s, %(efftime_backup_gfa_m4)s), (%(night_m5)s, %(expid_m5)s, %(tileid_m5)s, %(tilera_m5)s, %(tiledec_m5)s, %(date_obs_m5)s, %(mjd_m5)s, %(survey_m5)s, %(program_m5)s, %(faprgrm_m5)s, %(faflavor_m5)s, %(exptime_m5)s, %(efftime_spec_m5)s, %(goaltime_m5)s, %(goaltype_m5)s, %(mintfrac_m5)s, %(airmass_m5)s, %(ebv_m5)s, %(seeing_etc_m5)s, %(efftime_etc_m5)s, %(tsnr2_elg_m5)s, %(tsnr2_qso_m5)s, %(tsnr2_lrg_m5)s, %(tsnr2_lya_m5)s, %(tsnr2_bgs_m5)s, %(tsnr2_gpbdark_m5)s, %(tsnr2_gpbbright_m5)s, %(tsnr2_gpbbackup_m5)s, %(lrg_efftime_dark_m5)s, %(elg_efftime_dark_m5)s, %(bgs_efftime_bright_m5)s, %(lya_efftime_dark_m5)s, %(gpb_efftime_dark_m5)s, %(gpb_efftime_bright_m5)s, %(gpb_efftime_backup_m5)s, %(transparency_gfa_m5)s, %(seeing_gfa_m5)s, %(fiber_fracflux_gfa_m5)s, %(fiber_fracflux_elg_gfa_m5)s, %(fiber_fracflux_bgs_gfa_m5)s, %(fiberfac_gfa_m5)s, %(fiberfac_elg_gfa_m5)s, %(fiberfac_bgs_gfa_m5)s, %(airmass_gfa_m5)s, %(sky_mag_ab_gfa_m5)s, %(sky_mag_g_spec_m5)s, %(sky_mag_r_spec_m5)s, %(sky_mag_z_spec_m5)s, %(efftime_gfa_m5)s, %(efftime_dark_gfa_m5)s, %(efftime_bright_gfa_m5)s, %(efftime_backup_gfa_m5)s), (%(night_m6)s, %(expid_m6)s, %(tileid_m6)s, %(tilera_m6)s, %(tiledec_m6)s, %(date_obs_m6)s, %(mjd_m6)s, %(survey_m6)s, %(program_m6)s, %(faprgrm_m6)s, %(faflavor_m6)s, %(exptime_m6)s, %(efftime_spec_m6)s, %(goaltime_m6)s, %(goaltype_m6)s, %(mintfrac_m6)s, %(airmass_m6)s, %(ebv_m6)s, %(seeing_etc_m6)s, %(efftime_etc_m6)s, %(tsnr2_elg_m6)s, %(tsnr2_qso_m6)s, %(tsnr2_lrg_m6)s, %(tsnr2_lya_m6)s, %(tsnr2_bgs_m6)s, %(tsnr2_gpbdark_m6)s, %(tsnr2_gpbbright_m6)s, %(tsnr2_gpbbackup_m6)s, %(lrg_efftime_dark_m6)s, %(elg_efftime_dark_m6)s, %(bgs_efftime_bright_m6)s, %(lya_efftime_dark_m6)s, %(gpb_efftime_dark_m6)s, %(gpb_efftime_bright_m6)s, %(gpb_efftime_backup_m6)s, %(transparency_gfa_m6)s, %(seeing_gfa_m6)s, %(fiber_fracflux_gfa_m6)s, %(fiber_fracflux_elg_gfa_m6)s, %(fiber_fracflux_bgs_gfa_m6)s, %(fiberfac_gfa_m6)s, %(fiberfac_elg_gfa_m6)s, %(fiberfac_bgs_gfa_m6)s, %(airmass_gfa_m6)s, %(sky_mag_ab_gfa_m6)s, %(sky_mag_g_spec_m6)s, %(sky_mag_r_spec_m6)s, %(sky_mag_z_spec_m6)s, %(efftime_gfa_m6)s, %(efftime_dark_gfa_m6)s, %(efftime_bright_gfa_m6)s, %(efftime_backup_gfa_m6)s), (%(night_m7)s, %(expid_m7)s, %(tileid_m7)s, %(tilera_m7)s, %(tiledec_m7)s, %(date_obs_m7)s, %(mjd_m7)s, %(survey_m7)s, %(program_m7)s, %(faprgrm_m7)s, %(faflavor_m7)s, %(exptime_m7)s, %(efftime_spec_m7)s, %(goaltime_m7)s, %(goaltype_m7)s, %(mintfrac_m7)s, %(airmass_m7)s, %(ebv_m7)s, %(seeing_etc_m7)s, %(efftime_etc_m7)s, %(tsnr2_elg_m7)s, %(tsnr2_qso_m7)s, %(tsnr2_lrg_m7)s, %(tsnr2_lya_m7)s, %(tsnr2_bgs_m7)s, %(tsnr2_gpbdark_m7)s, %(tsnr2_gpbbright_m7)s, %(tsnr2_gpbbackup_m7)s, %(lrg_efftime_dark_m7)s, %(elg_efftime_dark_m7)s, %(bgs_efftime_bright_m7)s, %(lya_efftime_dark_m7)s, %(gpb_efftime_dark_m7)s, %(gpb_efftime_bright_m7)s, %(gpb_efftime_backup_m7)s, %(transparency_gfa_m7)s, %(seeing_gfa_m7)s, %(fiber_fracflux_gfa_m7)s, %(fiber_fracflux_elg_gfa_m7)s, %(fiber_fracflux_bgs_gfa_m7)s, %(fiberfac_gfa_m7)s, %(fiberfac_elg_gfa_m7)s, %(fiberfac_bgs_gfa_m7)s, %(airmass_gfa_m7)s, %(sky_mag_ab_gfa_m7)s, %(sky_mag_g_spec_m7)s, %(sky_mag_r_spec_m7)s, %(sky_mag_z_spec_m7)s, %(efftime_gfa_m7)s, %(efftime_dark_gfa_m7)s, %(efftime_bright_gfa_m7)s, %(efftime_backup_gfa_m7)s), (%(night_m8)s, %(expid_m8)s, %(tileid_m8)s, %(tilera_m8)s, %(tiledec_m8)s, %(date_obs_m8)s, %(mjd_m8)s, %(survey_m8)s, %(program_m8)s, %(faprgrm_m8)s, %(faflavor_m8)s, %(exptime_m8)s, %(efftime_spec_m8)s, %(goaltime_m8)s, %(goaltype_m8)s, %(mintfrac_m8)s, %(airmass_m8)s, %(ebv_m8)s, %(seeing_etc_m8)s, %(efftime_etc_m8)s, %(tsnr2_elg_m8)s, %(tsnr2_qso_m8)s, %(tsnr2_lrg_m8)s, %(tsnr2_lya_m8)s, %(tsnr2_bgs_m8)s, %(tsnr2_gpbdark_m8)s, %(tsnr2_gpbbright_m8)s, %(tsnr2_gpbbackup_m8)s, %(lrg_efftime_dark_m8)s, %(elg_efftime_dark_m8)s, %(bgs_efftime_bright_m8)s, %(lya_efftime_dark_m8)s, %(gpb_efftime_dark_m8)s, %(gpb_efftime_bright_m8)s, %(gpb_efftime_backup_m8)s, %(transparency_gfa_m8)s, %(seeing_gfa_m8)s, %(fiber_fracflux_gfa_m8)s, %(fiber_fracflux_elg_gfa_m8)s, %(fiber_fracflux_bgs_gfa_m8)s, %(fiberfac_gfa_m8)s, %(fiberfac_elg_gfa_m8)s, %(fiberfac_bgs_gfa_m8)s, %(airmass_gfa_m8)s, %(sky_mag_ab_gfa_m8)s, %(sky_mag_g_spec_m8)s, %(sky_mag_r_spec_m8)s, %(sky_mag_z_spec_m8)s, %(efftime_gfa_m8)s, %(efftime_dark_gfa_m8)s, %(efftime_bright_gfa_m8)s, %(efftime_backup_gfa_m8)s), (%(night_m9)s, %(expid_m9)s, %(tileid_m9)s, %(tilera_m9)s, %(tiledec_m9)s, %(date_obs_m9)s, %(mjd_m9)s, %(survey_m9)s, %(program_m9)s, %(faprgrm_m9)s, %(faflavor_m9)s, %(exptime_m9)s, %(efftime_spec_m9)s, %(goaltime_m9)s, %(goaltype_m9)s, %(mintfrac_m9)s, %(airmass_m9)s, %(ebv_m9)s, %(seeing_etc_m9)s, %(efftime_etc_m9)s, %(tsnr2_elg_m9)s, %(tsnr2_qso_m9)s, %(tsnr2_lrg_m9)s, %(tsnr2_lya_m9)s, %(tsnr2_bgs_m9)s, %(tsnr2_gpbdark_m9)s, %(tsnr2_gpbbright_m9)s, %(tsnr2_gpbbackup_m9)s, %(lrg_efftime_dark_m9)s, %(elg_efftime_dark_m9)s, %(bgs_efftime_bright_m9)s, %(lya_efftime_dark_m9)s, %(gpb_efftime_dark_m9)s, %(gpb_efftime_bright_m9)s, %(gpb_efftime_backup_m9)s, %(transparency_gfa_m9)s, %(seeing_gfa_m9)s, %(fiber_fracflux_gfa_m9)s, %(fiber_fracflux_elg_gfa_m9)s, %(fiber_fracflux_bgs_gfa_m9)s, %(fiberfac_gfa_m9)s, %(fiberfac_elg_gfa_m9)s, %(fiberfac_bgs_gfa_m9)s, %(airmass_gfa_m9)s, %(sky_mag_ab_gfa_m9)s, %(sky_mag_g_spec_m9)s, %(sky_mag_r_spec_m9)s, %(sky_mag_z_spec_m9)s, %(efftime_gfa_m9)s, %(efftime_dark_gfa_m9)s, %(efftime_bright_gfa_m9)s, %(efftime_backup_gfa_m9)s), (%(night_m10)s, %(expid_m10)s, %(tileid_m10)s, %(tilera_m10)s, %(tiledec_m10)s, %(date_obs_m10)s, %(mjd_m10)s, %(survey_m10)s, %(program_m10)s, %(faprgrm_m10)s, %(faflavor_m10)s, %(exptime_m10)s, %(efftime_spec_m10)s, %(goaltime_m10)s, %(goaltype_m10)s, %(mintfrac_m10)s, %(airmass_m10)s, %(ebv_m10)s, %(seeing_etc_m10)s, %(efftime_etc_m10)s, %(tsnr2_elg_m10)s, %(tsnr2_qso_m10)s, %(tsnr2_lrg_m10)s, %(tsnr2_lya_m10)s, %(tsnr2_bgs_m10)s, %(tsnr2_gpbdark_m10)s, %(tsnr2_gpbbright_m10)s, %(tsnr2_gpbbackup_m10)s, %(lrg_efftime_dark_m10)s, %(elg_efftime_dark_m10)s, %(bgs_efftime_bright_m10)s, %(lya_efftime_dark_m10)s, %(gpb_efftime_dark_m10)s, %(gpb_efftime_bright_m10)s, %(gpb_efftime_backup_m10)s, %(transparency_gfa_m10)s, %(seeing_gfa_m10)s, %(fiber_fracflux_gfa_m10)s, %(fiber_fracflux_elg_gfa_m10)s, %(fiber_fracflux_bgs_gfa_m10)s, %(fiberfac_gfa_m10)s, %(fiberfac_elg_gfa_m10)s, %(fiberfac_bgs_gfa_m10)s, %(airmass_gfa_m10)s, %(sky_mag_ab_gfa_m10)s, %(sky_mag_g_spec_m10)s, %(sky_mag_r_spec_m10)s, %(sky_mag_z_spec_m10)s, %(efftime_gfa_m10)s, %(efftime_dark_gfa_m10)s, %(efftime_bright_gfa_m10)s, %(efftime_backup_gfa_m10)s), (%(night_m11)s, %(expid_m11)s, %(tileid_m11)s, %(tilera_m11)s, %(tiledec_m11)s, %(date_obs_m11)s, %(mjd_m11)s, %(survey_m11)s, %(program_m11)s, %(faprgrm_m11)s, %(faflavor_m11)s, %(exptime_m11)s, %(efftime_spec_m11)s, %(goaltime_m11)s, %(goaltype_m11)s, %(mintfrac_m11)s, %(airmass_m11)s, %(ebv_m11)s, %(seeing_etc_m11)s, %(efftime_etc_m11)s, %(tsnr2_elg_m11)s, %(tsnr2_qso_m11)s, %(tsnr2_lrg_m11)s, %(tsnr2_lya_m11)s, %(tsnr2_bgs_m11)s, %(tsnr2_gpbdark_m11)s, %(tsnr2_gpbbright_m11)s, %(tsnr2_gpbbackup_m11)s, %(lrg_efftime_dark_m11)s, %(elg_efftime_dark_m11)s, %(bgs_efftime_bright_m11)s, %(lya_efftime_dark_m11)s, %(gpb_efftime_dark_m11)s, %(gpb_efftime_bright_m11)s, %(gpb_efftime_backup_m11)s, %(transparency_gfa_m11)s, %(seeing_gfa_m11)s, %(fiber_fracflux_gfa_m11)s, %(fiber_fracflux_elg_gfa_m11)s, %(fiber_fracflux_bgs_gfa_m11)s, %(fiberfac_gfa_m11)s, %(fiberfac_elg_gfa_m11)s, %(fiberfac_bgs_gfa_m11)s, %(airmass_gfa_m11)s, %(sky_mag_ab_gfa_m11)s, %(sky_mag_g_spec_m11)s, %(sky_mag_r_spec_m11)s, %(sky_mag_z_spec_m11)s, %(efftime_gfa_m11)s, %(efftime_dark_gfa_m11)s, %(efftime_bright_gfa_m11)s, %(efftime_backup_gfa_m11)s), (%(night_m12)s, %(expid_m12)s, %(tileid_m12)s, %(tilera_m12)s, %(tiledec_m12)s, %(date_obs_m12)s, %(mjd_m12)s, %(survey_m12)s, %(program_m12)s, %(faprgrm_m12)s, %(faflavor_m12)s, %(exptime_m12)s, %(efftime_spec_m12)s, %(goaltime_m12)s, %(goaltype_m12)s, %(mintfrac_m12)s, %(airmass_m12)s, %(ebv_m12)s, %(seeing_etc_m12)s, %(efftime_etc_m12)s, %(tsnr2_elg_m12)s, %(tsnr2_qso_m12)s, %(tsnr2_lrg_m12)s, %(tsnr2_lya_m12)s, %(tsnr2_bgs_m12)s, %(tsnr2_gpbdark_m12)s, %(tsnr2_gpbbright_m12)s, %(tsnr2_gpbbackup_m12)s, %(lrg_efftime_dark_m12)s, %(elg_efftime_dark_m12)s, %(bgs_efftime_bright_m12)s, %(lya_efftime_dark_m12)s, %(gpb_efftime_dark_m12)s, %(gpb_efftime_bright_m12)s, %(gpb_efftime_backup_m12)s, %(transparency_gfa_m12)s, %(seeing_gfa_m12)s, %(fiber_fracflux_gfa_m12)s, %(fiber_fracflux_elg_gfa_m12)s, %(fiber_fracflux_bgs_gfa_m12)s, %(fiberfac_gfa_m12)s, %(fiberfac_elg_gfa_m12)s, %(fiberfac_bgs_gfa_m12)s, %(airmass_gfa_m12)s, %(sky_mag_ab_gfa_m12)s, %(sky_mag_g_spec_m12)s, %(sky_mag_r_spec_m12)s, %(sky_mag_z_spec_m12)s, %(efftime_gfa_m12)s, %(efftime_dark_gfa_m12)s, %(efftime_bright_gfa_m12)s, %(efftime_backup_gfa_m12)s), (%(night_m13)s, %(expid_m13)s, %(tileid_m13)s, %(tilera_m13)s, %(tiledec_m13)s, %(date_obs_m13)s, %(mjd_m13)s, %(survey_m13)s, %(program_m13)s, %(faprgrm_m13)s, %(faflavor_m13)s, %(exptime_m13)s, %(efftime_spec_m13)s, %(goaltime_m13)s, %(goaltype_m13)s, %(mintfrac_m13)s, %(airmass_m13)s, %(ebv_m13)s, %(seeing_etc_m13)s, %(efftime_etc_m13)s, %(tsnr2_elg_m13)s, %(tsnr2_qso_m13)s, %(tsnr2_lrg_m13)s, %(tsnr2_lya_m13)s, %(tsnr2_bgs_m13)s, %(tsnr2_gpbdark_m13)s, %(tsnr2_gpbbright_m13)s, %(tsnr2_gpbbackup_m13)s, %(lrg_efftime_dark_m13)s, %(elg_efftime_dark_m13)s, %(bgs_efftime_bright_m13)s, %(lya_efftime_dark_m13)s, %(gpb_efftime_dark_m13)s, %(gpb_efftime_bright_m13)s, %(gpb_efftime_backup_m13)s, %(transparency_gfa_m13)s, %(seeing_gfa_m13)s, %(fiber_fracflux_gfa_m13)s, %(fiber_fracflux_elg_gfa_m13)s, %(fiber_fracflux_bgs_gfa_m13)s, %(fiberfac_gfa_m13)s, %(fiberfac_elg_gfa_m13)s, %(fiberfac_bgs_gfa_m13)s, %(airmass_gfa_m13)s, %(sky_mag_ab_gfa_m13)s, %(sky_mag_g_spec_m13)s, %(sky_mag_r_spec_m13)s, %(sky_mag_z_spec_m13)s, %(efftime_gfa_m13)s, %(efftime_dark_gfa_m13)s, %(efftime_bright_gfa_m13)s, %(efftime_backup_gfa_m13)s), (%(night_m14)s, %(expid_m14)s, %(tileid_m14)s, %(tilera_m14)s, %(tiledec_m14)s, %(date_obs_m14)s, %(mjd_m14)s, %(survey_m14)s, %(program_m14)s, %(faprgrm_m14)s, %(faflavor_m14)s, %(exptime_m14)s, %(efftime_spec_m14)s, %(goaltime_m14)s, %(goaltype_m14)s, %(mintfrac_m14)s, %(airmass_m14)s, %(ebv_m14)s, %(seeing_etc_m14)s, %(efftime_etc_m14)s, %(tsnr2_elg_m14)s, %(tsnr2_qso_m14)s, %(tsnr2_lrg_m14)s, %(tsnr2_lya_m14)s, %(tsnr2_bgs_m14)s, %(tsnr2_gpbdark_m14)s, %(tsnr2_gpbbright_m14)s, %(tsnr2_gpbbackup_m14)s, %(lrg_efftime_dark_m14)s, %(elg_efftime_dark_m14)s, %(bgs_efftime_bright_m14)s, %(lya_efftime_dark_m14)s, %(gpb_efftime_dark_m14)s, %(gpb_efftime_bright_m14)s, %(gpb_efftime_backup_m14)s, %(transparency_gfa_m14)s, %(seeing_gfa_m14)s, %(fiber_fracflux_gfa_m14)s, %(fiber_fracflux_elg_gfa_m14)s, %(fiber_fracflux_bgs_gfa_m14)s, %(fiberfac_gfa_m14)s, %(fiberfac_elg_gfa_m14)s, %(fiberfac_bgs_gfa_m14)s, %(airmass_gfa_m14)s, %(sky_mag_ab_gfa_m14)s, %(sky_mag_g_spec_m14)s, %(sky_mag_r_spec_m14)s, %(sky_mag_z_spec_m14)s, %(efftime_gfa_m14)s, %(efftime_dark_gfa_m14)s, %(efftime_bright_gfa_m14)s, %(efftime_backup_gfa_m14)s), (%(night_m15)s, %(expid_m15)s, %(tileid_m15)s, %(tilera_m15)s, %(tiledec_m15)s, %(date_obs_m15)s, %(mjd_m15)s, %(survey_m15)s, %(program_m15)s, %(faprgrm_m15)s, %(faflavor_m15)s, %(exptime_m15)s, %(efftime_spec_m15)s, %(goaltime_m15)s, %(goaltype_m15)s, %(mintfrac_m15)s, %(airmass_m15)s, %(ebv_m15)s, %(seeing_etc_m15)s, %(efftime_etc_m15)s, %(tsnr2_elg_m15)s, %(tsnr2_qso_m15)s, %(tsnr2_lrg_m15)s, %(tsnr2_lya_m15)s, %(tsnr2_bgs_m15)s, %(tsnr2_gpbdark_m15)s, %(tsnr2_gpbbright_m15)s, %(tsnr2_gpbbackup_m15)s, %(lrg_efftime_dark_m15)s, %(elg_efftime_dark_m15)s, %(bgs_efftime_bright_m15)s, %(lya_efftime_dark_m15)s, %(gpb_efftime_dark_m15)s, %(gpb_efftime_bright_m15)s, %(gpb_efftime_backup_m15)s, %(transparency_gfa_m15)s, %(seeing_gfa_m15)s, %(fiber_fracflux_gfa_m15)s, %(fiber_fracflux_elg_gfa_m15)s, %(fiber_fracflux_bgs_gfa_m15)s, %(fiberfac_gfa_m15)s, %(fiberfac_elg_gfa_m15)s, %(fiberfac_bgs_gfa_m15)s, %(airmass_gfa_m15)s, %(sky_mag_ab_gfa_m15)s, %(sky_mag_g_spec_m15)s, %(sky_mag_r_spec_m15)s, %(sky_mag_z_spec_m15)s, %(efftime_gfa_m15)s, %(efftime_dark_gfa_m15)s, %(efftime_bright_gfa_m15)s, %(efftime_backup_gfa_m15)s), (%(night_m16)s, %(expid_m16)s, %(tileid_m16)s, %(tilera_m16)s, %(tiledec_m16)s, %(date_obs_m16)s, %(mjd_m16)s, %(survey_m16)s, %(program_m16)s, %(faprgrm_m16)s, %(faflavor_m16)s, %(exptime_m16)s, %(efftime_spec_m16)s, %(goaltime_m16)s, %(goaltype_m16)s, %(mintfrac_m16)s, %(airmass_m16)s, %(ebv_m16)s, %(seeing_etc_m16)s, %(efftime_etc_m16)s, %(tsnr2_elg_m16)s, %(tsnr2_qso_m16)s, %(tsnr2_lrg_m16)s, %(tsnr2_lya_m16)s, %(tsnr2_bgs_m16)s, %(tsnr2_gpbdark_m16)s, %(tsnr2_gpbbright_m16)s, %(tsnr2_gpbbackup_m16)s, %(lrg_efftime_dark_m16)s, %(elg_efftime_dark_m16)s, %(bgs_efftime_bright_m16)s, %(lya_efftime_dark_m16)s, %(gpb_efftime_dark_m16)s, %(gpb_efftime_bright_m16)s, %(gpb_efftime_backup_m16)s, %(transparency_gfa_m16)s, %(seeing_gfa_m16)s, %(fiber_fracflux_gfa_m16)s, %(fiber_fracflux_elg_gfa_m16)s, %(fiber_fracflux_bgs_gfa_m16)s, %(fiberfac_gfa_m16)s, %(fiberfac_elg_gfa_m16)s, %(fiberfac_bgs_gfa_m16)s, %(airmass_gfa_m16)s, %(sky_mag_ab_gfa_m16)s, %(sky_mag_g_spec_m16)s, %(sky_mag_r_spec_m16)s, %(sky_mag_z_spec_m16)s, %(efftime_gfa_m16)s, %(efftime_dark_gfa_m16)s, %(efftime_bright_gfa_m16)s, %(efftime_backup_gfa_m16)s), (%(night_m17)s, %(expid_m17)s, %(tileid_m17)s, %(tilera_m17)s, %(tiledec_m17)s, %(date_obs_m17)s, %(mjd_m17)s, %(survey_m17)s, %(program_m17)s, %(faprgrm_m17)s, %(faflavor_m17)s, %(exptime_m17)s, %(efftime_spec_m17)s, %(goaltime_m17)s, %(goaltype_m17)s, %(mintfrac_m17)s, %(airmass_m17)s, %(ebv_m17)s, %(seeing_etc_m17)s, %(efftime_etc_m17)s, %(tsnr2_elg_m17)s, %(tsnr2_qso_m17)s, %(tsnr2_lrg_m17)s, %(tsnr2_lya_m17)s, %(tsnr2_bgs_m17)s, %(tsnr2_gpbdark_m17)s, %(tsnr2_gpbbright_m17)s, %(tsnr2_gpbbackup_m17)s, %(lrg_efftime_dark_m17)s, %(elg_efftime_dark_m17)s, %(bgs_efftime_bright_m17)s, %(lya_efftime_dark_m17)s, %(gpb_efftime_dark_m17)s, %(gpb_efftime_bright_m17)s, %(gpb_efftime_backup_m17)s, %(transparency_gfa_m17)s, %(seeing_gfa_m17)s, %(fiber_fracflux_gfa_m17)s, %(fiber_fracflux_elg_gfa_m17)s, %(fiber_fracflux_bgs_gfa_m17)s, %(fiberfac_gfa_m17)s, %(fiberfac_elg_gfa_m17)s, %(fiberfac_bgs_gfa_m17)s, %(airmass_gfa_m17)s, %(sky_mag_ab_gfa_m17)s, %(sky_mag_g_spec_m17)s, %(sky_mag_r_spec_m17)s, %(sky_mag_z_spec_m17)s, %(efftime_gfa_m17)s, %(efftime_dark_gfa_m17)s, %(efftime_bright_gfa_m17)s, %(efftime_backup_gfa_m17)s), (%(night_m18)s, %(expid_m18)s, %(tileid_m18)s, %(tilera_m18)s, %(tiledec_m18)s, %(date_obs_m18)s, %(mjd_m18)s, %(survey_m18)s, %(program_m18)s, %(faprgrm_m18)s, %(faflavor_m18)s, %(exptime_m18)s, %(efftime_spec_m18)s, %(goaltime_m18)s, %(goaltype_m18)s, %(mintfrac_m18)s, %(airmass_m18)s, %(ebv_m18)s, %(seeing_etc_m18)s, %(efftime_etc_m18)s, %(tsnr2_elg_m18)s, %(tsnr2_qso_m18)s, %(tsnr2_lrg_m18)s, %(tsnr2_lya_m18)s, %(tsnr2_bgs_m18)s, %(tsnr2_gpbdark_m18)s, %(tsnr2_gpbbright_m18)s, %(tsnr2_gpbbackup_m18)s, %(lrg_efftime_dark_m18)s, %(elg_efftime_dark_m18)s, %(bgs_efftime_bright_m18)s, %(lya_efftime_dark_m18)s, %(gpb_efftime_dark_m18)s, %(gpb_efftime_bright_m18)s, %(gpb_efftime_backup_m18)s, %(transparency_gfa_m18)s, %(seeing_gfa_m18)s, %(fiber_fracflux_gfa_m18)s, %(fiber_fracflux_elg_gfa_m18)s, %(fiber_fracflux_bgs_gfa_m18)s, %(fiberfac_gfa_m18)s, %(fiberfac_elg_gfa_m18)s, %(fiberfac_bgs_gfa_m18)s, %(airmass_gfa_m18)s, %(sky_mag_ab_gfa_m18)s, %(sky_mag_g_spec_m18)s, %(sky_mag_r_spec_m18)s, %(sky_mag_z_spec_m18)s, %(efftime_gfa_m18)s, %(efftime_dark_gfa_m18)s, %(efftime_bright_gfa_m18)s, %(efftime_backup_gfa_m18)s), (%(night_m19)s, %(expid_m19)s, %(tileid_m19)s, %(tilera_m19)s, %(tiledec_m19)s, %(date_obs_m19)s, %(mjd_m19)s, %(survey_m19)s, %(program_m19)s, %(faprgrm_m19)s, %(faflavor_m19)s, %(exptime_m19)s, %(efftime_spec_m19)s, %(goaltime_m19)s, %(goaltype_m19)s, %(mintfrac_m19)s, %(airmass_m19)s, %(ebv_m19)s, %(seeing_etc_m19)s, %(efftime_etc_m19)s, %(tsnr2_elg_m19)s, %(tsnr2_qso_m19)s, %(tsnr2_lrg_m19)s, %(tsnr2_lya_m19)s, %(tsnr2_bgs_m19)s, %(tsnr2_gpbdark_m19)s, %(tsnr2_gpbbright_m19)s, %(tsnr2_gpbbackup_m19)s, %(lrg_efftime_dark_m19)s, %(elg_efftime_dark_m19)s, %(bgs_efftime_bright_m19)s, %(lya_efftime_dark_m19)s, %(gpb_efftime_dark_m19)s, %(gpb_efftime_bright_m19)s, %(gpb_efftime_backup_m19)s, %(transparency_gfa_m19)s, %(seeing_gfa_m19)s, %(fiber_fracflux_gfa_m19)s, %(fiber_fracflux_elg_gfa_m19)s, %(fiber_fracflux_bgs_gfa_m19)s, %(fiberfac_gfa_m19)s, %(fiberfac_elg_gfa_m19)s, %(fiberfac_bgs_gfa_m19)s, %(airmass_gfa_m19)s, %(sky_mag_ab_gfa_m19)s, %(sky_mag_g_spec_m19)s, %(sky_mag_r_spec_m19)s, %(sky_mag_z_spec_m19)s, %(efftime_gfa_m19)s, %(efftime_dark_gfa_m19)s, %(efftime_bright_gfa_m19)s, %(efftime_backup_gfa_m19)s), (%(night_m20)s, %(expid_m20)s, %(tileid_m20)s, %(tilera_m20)s, %(tiledec_m20)s, %(date_obs_m20)s, %(mjd_m20)s, %(survey_m20)s, %(program_m20)s, %(faprgrm_m20)s, %(faflavor_m20)s, %(exptime_m20)s, %(efftime_spec_m20)s, %(goaltime_m20)s, %(goaltype_m20)s, %(mintfrac_m20)s, %(airmass_m20)s, %(ebv_m20)s, %(seeing_etc_m20)s, %(efftime_etc_m20)s, %(tsnr2_elg_m20)s, %(tsnr2_qso_m20)s, %(tsnr2_lrg_m20)s, %(tsnr2_lya_m20)s, %(tsnr2_bgs_m20)s, %(tsnr2_gpbdark_m20)s, %(tsnr2_gpbbright_m20)s, %(tsnr2_gpbbackup_m20)s, %(lrg_efftime_dark_m20)s, %(elg_efftime_dark_m20)s, %(bgs_efftime_bright_m20)s, %(lya_efftime_dark_m20)s, %(gpb_efftime_dark_m20)s, %(gpb_efftime_bright_m20)s, %(gpb_efftime_backup_m20)s, %(transparency_gfa_m20)s, %(seeing_gfa_m20)s, %(fiber_fracflux_gfa_m20)s, %(fiber_fracflux_elg_gfa_m20)s, %(fiber_fracflux_bgs_gfa_m20)s, %(fiberfac_gfa_m20)s, %(fiberfac_elg_gfa_m20)s, %(fiberfac_bgs_gfa_m20)s, %(airmass_gfa_m20)s, %(sky_mag_ab_gfa_m20)s, %(sky_mag_g_spec_m20)s, %(sky_mag_r_spec_m20)s, %(sky_mag_z_spec_m20)s, %(efftime_gfa_m20)s, %(efftime_dark_gfa_m20)s, %(efftime_bright_gfa_m20)s, %(efftime_backup_gfa_m20)s), (%(night_m21)s, %(expid_m21)s, %(tileid_m21)s, %(tilera_m21)s, %(tiledec_m21)s, %(date_obs_m21)s, %(mjd_m21)s, %(survey_m21)s, %(program_m21)s, %(faprgrm_m21)s, %(faflavor_m21)s, %(exptime_m21)s, %(efftime_spec_m21)s, %(goaltime_m21)s, %(goaltype_m21)s, %(mintfrac_m21)s, %(airmass_m21)s, %(ebv_m21)s, %(seeing_etc_m21)s, %(efftime_etc_m21)s, %(tsnr2_elg_m21)s, %(tsnr2_qso_m21)s, %(tsnr2_lrg_m21)s, %(tsnr2_lya_m21)s, %(tsnr2_bgs_m21)s, %(tsnr2_gpbdark_m21)s, %(tsnr2_gpbbright_m21)s, %(tsnr2_gpbbackup_m21)s, %(lrg_efftime_dark_m21)s, %(elg_efftime_dark_m21)s, %(bgs_efftime_bright_m21)s, %(lya_efftime_dark_m21)s, %(gpb_efftime_dark_m21)s, %(gpb_efftime_bright_m21)s, %(gpb_efftime_backup_m21)s, %(transparency_gfa_m21)s, %(seeing_gfa_m21)s, %(fiber_fracflux_gfa_m21)s, %(fiber_fracflux_elg_gfa_m21)s, %(fiber_fracflux_bgs_gfa_m21)s, %(fiberfac_gfa_m21)s, %(fiberfac_elg_gfa_m21)s, %(fiberfac_bgs_gfa_m21)s, %(airmass_gfa_m21)s, %(sky_mag_ab_gfa_m21)s, %(sky_mag_g_spec_m21)s, %(sky_mag_r_spec_m21)s, %(sky_mag_z_spec_m21)s, %(efftime_gfa_m21)s, %(efftime_dark_gfa_m21)s, %(efftime_bright_gfa_m21)s, %(efftime_backup_gfa_m21)s), (%(night_m22)s, %(expid_m22)s, %(tileid_m22)s, %(tilera_m22)s, %(tiledec_m22)s, %(date_obs_m22)s, %(mjd_m22)s, %(survey_m22)s, %(program_m22)s, %(faprgrm_m22)s, %(faflavor_m22)s, %(exptime_m22)s, %(efftime_spec_m22)s, %(goaltime_m22)s, %(goaltype_m22)s, %(mintfrac_m22)s, %(airmass_m22)s, %(ebv_m22)s, %(seeing_etc_m22)s, %(efftime_etc_m22)s, %(tsnr2_elg_m22)s, %(tsnr2_qso_m22)s, %(tsnr2_lrg_m22)s, %(tsnr2_lya_m22)s, %(tsnr2_bgs_m22)s, %(tsnr2_gpbdark_m22)s, %(tsnr2_gpbbright_m22)s, %(tsnr2_gpbbackup_m22)s, %(lrg_efftime_dark_m22)s, %(elg_efftime_dark_m22)s, %(bgs_efftime_bright_m22)s, %(lya_efftime_dark_m22)s, %(gpb_efftime_dark_m22)s, %(gpb_efftime_bright_m22)s, %(gpb_efftime_backup_m22)s, %(transparency_gfa_m22)s, %(seeing_gfa_m22)s, %(fiber_fracflux_gfa_m22)s, %(fiber_fracflux_elg_gfa_m22)s, %(fiber_fracflux_bgs_gfa_m22)s, %(fiberfac_gfa_m22)s, %(fiberfac_elg_gfa_m22)s, %(fiberfac_bgs_gfa_m22)s, %(airmass_gfa_m22)s, %(sky_mag_ab_gfa_m22)s, %(sky_mag_g_spec_m22)s, %(sky_mag_r_spec_m22)s, %(sky_mag_z_spec_m22)s, %(efftime_gfa_m22)s, %(efftime_dark_gfa_m22)s, %(efftime_bright_gfa_m22)s, %(efftime_backup_gfa_m22)s), (%(night_m23)s, %(expid_m23)s, %(tileid_m23)s, %(tilera_m23)s, %(tiledec_m23)s, %(date_obs_m23)s, %(mjd_m23)s, %(survey_m23)s, %(program_m23)s, %(faprgrm_m23)s, %(faflavor_m23)s, %(exptime_m23)s, %(efftime_spec_m23)s, %(goaltime_m23)s, %(goaltype_m23)s, %(mintfrac_m23)s, %(airmass_m23)s, %(ebv_m23)s, %(seeing_etc_m23)s, %(efftime_etc_m23)s, %(tsnr2_elg_m23)s, %(tsnr2_qso_m23)s, %(tsnr2_lrg_m23)s, %(tsnr2_lya_m23)s, %(tsnr2_bgs_m23)s, %(tsnr2_gpbdark_m23)s, %(tsnr2_gpbbright_m23)s, %(tsnr2_gpbbackup_m23)s, %(lrg_efftime_dark_m23)s, %(elg_efftime_dark_m23)s, %(bgs_efftime_bright_m23)s, %(lya_efftime_dark_m23)s, %(gpb_efftime_dark_m23)s, %(gpb_efftime_bright_m23)s, %(gpb_efftime_backup_m23)s, %(transparency_gfa_m23)s, %(seeing_gfa_m23)s, %(fiber_fracflux_gfa_m23)s, %(fiber_fracflux_elg_gfa_m23)s, %(fiber_fracflux_bgs_gfa_m23)s, %(fiberfac_gfa_m23)s, %(fiberfac_elg_gfa_m23)s, %(fiberfac_bgs_gfa_m23)s, %(airmass_gfa_m23)s, %(sky_mag_ab_gfa_m23)s, %(sky_mag_g_spec_m23)s, %(sky_mag_r_spec_m23)s, %(sky_mag_z_spec_m23)s, %(efftime_gfa_m23)s, %(efftime_dark_gfa_m23)s, %(efftime_bright_gfa_m23)s, %(efftime_backup_gfa_m23)s), (%(night_m24)s, %(expid_m24)s, %(tileid_m24)s, %(tilera_m24)s, %(tiledec_m24)s, %(date_obs_m24)s, %(mjd_m24)s, %(survey_m24)s, %(program_m24)s, %(faprgrm_m24)s, %(faflavor_m24)s, %(exptime_m24)s, %(efftime_spec_m24)s, %(goaltime_m24)s, %(goaltype_m24)s, %(mintfrac_m24)s, %(airmass_m24)s, %(ebv_m24)s, %(seeing_etc_m24)s, %(efftime_etc_m24)s, %(tsnr2_elg_m24)s, %(tsnr2_qso_m24)s, %(tsnr2_lrg_m24)s, %(tsnr2_lya_m24)s, %(tsnr2_bgs_m24)s, %(tsnr2_gpbdark_m24)s, %(tsnr2_gpbbright_m24)s, %(tsnr2_gpbbackup_m24)s, %(lrg_efftime_dark_m24)s, %(elg_efftime_dark_m24)s, %(bgs_efftime_bright_m24)s, %(lya_efftime_dark_m24)s, %(gpb_efftime_dark_m24)s, %(gpb_efftime_bright_m24)s, %(gpb_efftime_backup_m24)s, %(transparency_gfa_m24)s, %(seeing_gfa_m24)s, %(fiber_fracflux_gfa_m24)s, %(fiber_fracflux_elg_gfa_m24)s, %(fiber_fracflux_bgs_gfa_m24)s, %(fiberfac_gfa_m24)s, %(fiberfac_elg_gfa_m24)s, %(fiberfac_bgs_gfa_m24)s, %(airmass_gfa_m24)s, %(sky_mag_ab_gfa_m24)s, %(sky_mag_g_spec_m24)s, %(sky_mag_r_spec_m24)s, %(sky_mag_z_spec_m24)s, %(efftime_gfa_m24)s, %(efftime_dark_gfa_m24)s, %(efftime_bright_gfa_m24)s, %(efftime_backup_gfa_m24)s), (%(night_m25)s, %(expid_m25)s, %(tileid_m25)s, %(tilera_m25)s, %(tiledec_m25)s, %(date_obs_m25)s, %(mjd_m25)s, %(survey_m25)s, %(program_m25)s, %(faprgrm_m25)s, %(faflavor_m25)s, %(exptime_m25)s, %(efftime_spec_m25)s, %(goaltime_m25)s, %(goaltype_m25)s, %(mintfrac_m25)s, %(airmass_m25)s, %(ebv_m25)s, %(seeing_etc_m25)s, %(efftime_etc_m25)s, %(tsnr2_elg_m25)s, %(tsnr2_qso_m25)s, %(tsnr2_lrg_m25)s, %(tsnr2_lya_m25)s, %(tsnr2_bgs_m25)s, %(tsnr2_gpbdark_m25)s, %(tsnr2_gpbbright_m25)s, %(tsnr2_gpbbackup_m25)s, %(lrg_efftime_dark_m25)s, %(elg_efftime_dark_m25)s, %(bgs_efftime_bright_m25)s, %(lya_efftime_dark_m25)s, %(gpb_efftime_dark_m25)s, %(gpb_efftime_bright_m25)s, %(gpb_efftime_backup_m25)s, %(transparency_gfa_m25)s, %(seeing_gfa_m25)s, %(fiber_fracflux_gfa_m25)s, %(fiber_fracflux_elg_gfa_m25)s, %(fiber_fracflux_bgs_gfa_m25)s, %(fiberfac_gfa_m25)s, %(fiberfac_elg_gfa_m25)s, %(fiberfac_bgs_gfa_m25)s, %(airmass_gfa_m25)s, %(sky_mag_ab_gfa_m25)s, %(sky_mag_g_spec_m25)s, %(sky_mag_r_spec_m25)s, %(sky_mag_z_spec_m25)s, %(efftime_gfa_m25)s, %(efftime_dark_gfa_m25)s, %(efftime_bright_gfa_m25)s, %(efftime_backup_gfa_m25)s), (%(night_m26)s, %(expid_m26)s, %(tileid_m26)s, %(tilera_m26)s, %(tiledec_m26)s, %(date_obs_m26)s, %(mjd_m26)s, %(survey_m26)s, %(program_m26)s, %(faprgrm_m26)s, %(faflavor_m26)s, %(exptime_m26)s, %(efftime_spec_m26)s, %(goaltime_m26)s, %(goaltype_m26)s, %(mintfrac_m26)s, %(airmass_m26)s, %(ebv_m26)s, %(seeing_etc_m26)s, %(efftime_etc_m26)s, %(tsnr2_elg_m26)s, %(tsnr2_qso_m26)s, %(tsnr2_lrg_m26)s, %(tsnr2_lya_m26)s, %(tsnr2_bgs_m26)s, %(tsnr2_gpbdark_m26)s, %(tsnr2_gpbbright_m26)s, %(tsnr2_gpbbackup_m26)s, %(lrg_efftime_dark_m26)s, %(elg_efftime_dark_m26)s, %(bgs_efftime_bright_m26)s, %(lya_efftime_dark_m26)s, %(gpb_efftime_dark_m26)s, %(gpb_efftime_bright_m26)s, %(gpb_efftime_backup_m26)s, %(transparency_gfa_m26)s, %(seeing_gfa_m26)s, %(fiber_fracflux_gfa_m26)s, %(fiber_fracflux_elg_gfa_m26)s, %(fiber_fracflux_bgs_gfa_m26)s, %(fiberfac_gfa_m26)s, %(fiberfac_elg_gfa_m26)s, %(fiberfac_bgs_gfa_m26)s, %(airmass_gfa_m26)s, %(sky_mag_ab_gfa_m26)s, %(sky_mag_g_spec_m26)s, %(sky_mag_r_spec_m26)s, %(sky_mag_z_spec_m26)s, %(efftime_gfa_m26)s, %(efftime_dark_gfa_m26)s, %(efftime_bright_gfa_m26)s, %(efftime_backup_gfa_m26)s), (%(night_m27)s, %(expid_m27)s, %(tileid_m27)s, %(tilera_m27)s, %(tiledec_m27)s, %(date_obs_m27)s, %(mjd_m27)s, %(survey_m27)s, %(program_m27)s, %(faprgrm_m27)s, %(faflavor_m27)s, %(exptime_m27)s, %(efftime_spec_m27)s, %(goaltime_m27)s, %(goaltype_m27)s, %(mintfrac_m27)s, %(airmass_m27)s, %(ebv_m27)s, %(seeing_etc_m27)s, %(efftime_etc_m27)s, %(tsnr2_elg_m27)s, %(tsnr2_qso_m27)s, %(tsnr2_lrg_m27)s, %(tsnr2_lya_m27)s, %(tsnr2_bgs_m27)s, %(tsnr2_gpbdark_m27)s, %(tsnr2_gpbbright_m27)s, %(tsnr2_gpbbackup_m27)s, %(lrg_efftime_dark_m27)s, %(elg_efftime_dark_m27)s, %(bgs_efftime_bright_m27)s, %(lya_efftime_dark_m27)s, %(gpb_efftime_dark_m27)s, %(gpb_efftime_bright_m27)s, %(gpb_efftime_backup_m27)s, %(transparency_gfa_m27)s, %(seeing_gfa_m27)s, %(fiber_fracflux_gfa_m27)s, %(fiber_fracflux_elg_gfa_m27)s, %(fiber_fracflux_bgs_gfa_m27)s, %(fiberfac_gfa_m27)s, %(fiberfac_elg_gfa_m27)s, %(fiberfac_bgs_gfa_m27)s, %(airmass_gfa_m27)s, %(sky_mag_ab_gfa_m27)s, %(sky_mag_g_spec_m27)s, %(sky_mag_r_spec_m27)s, %(sky_mag_z_spec_m27)s, %(efftime_gfa_m27)s, %(efftime_dark_gfa_m27)s, %(efftime_bright_gfa_m27)s, %(efftime_backup_gfa_m27)s), (%(night_m28)s, %(expid_m28)s, %(tileid_m28)s, %(tilera_m28)s, %(tiledec_m28)s, %(date_obs_m28)s, %(mjd_m28)s, %(survey_m28)s, %(program_m28)s, %(faprgrm_m28)s, %(faflavor_m28)s, %(exptime_m28)s, %(efftime_spec_m28)s, %(goaltime_m28)s, %(goaltype_m28)s, %(mintfrac_m28)s, %(airmass_m28)s, %(ebv_m28)s, %(seeing_etc_m28)s, %(efftime_etc_m28)s, %(tsnr2_elg_m28)s, %(tsnr2_qso_m28)s, %(tsnr2_lrg_m28)s, %(tsnr2_lya_m28)s, %(tsnr2_bgs_m28)s, %(tsnr2_gpbdark_m28)s, %(tsnr2_gpbbright_m28)s, %(tsnr2_gpbbackup_m28)s, %(lrg_efftime_dark_m28)s, %(elg_efftime_dark_m28)s, %(bgs_efftime_bright_m28)s, %(lya_efftime_dark_m28)s, %(gpb_efftime_dark_m28)s, %(gpb_efftime_bright_m28)s, %(gpb_efftime_backup_m28)s, %(transparency_gfa_m28)s, %(seeing_gfa_m28)s, %(fiber_fracflux_gfa_m28)s, %(fiber_fracflux_elg_gfa_m28)s, %(fiber_fracflux_bgs_gfa_m28)s, %(fiberfac_gfa_m28)s, %(fiberfac_elg_gfa_m28)s, %(fiberfac_bgs_gfa_m28)s, %(airmass_gfa_m28)s, %(sky_mag_ab_gfa_m28)s, %(sky_mag_g_spec_m28)s, %(sky_mag_r_spec_m28)s, %(sky_mag_z_spec_m28)s, %(efftime_gfa_m28)s, %(efftime_dark_gfa_m28)s, %(efftime_bright_gfa_m28)s, %(efftime_backup_gfa_m28)s), (%(night_m29)s, %(expid_m29)s, %(tileid_m29)s, %(tilera_m29)s, %(tiledec_m29)s, %(date_obs_m29)s, %(mjd_m29)s, %(survey_m29)s, %(program_m29)s, %(faprgrm_m29)s, %(faflavor_m29)s, %(exptime_m29)s, %(efftime_spec_m29)s, %(goaltime_m29)s, %(goaltype_m29)s, %(mintfrac_m29)s, %(airmass_m29)s, %(ebv_m29)s, %(seeing_etc_m29)s, %(efftime_etc_m29)s, %(tsnr2_elg_m29)s, %(tsnr2_qso_m29)s, %(tsnr2_lrg_m29)s, %(tsnr2_lya_m29)s, %(tsnr2_bgs_m29)s, %(tsnr2_gpbdark_m29)s, %(tsnr2_gpbbright_m29)s, %(tsnr2_gpbbackup_m29)s, %(lrg_efftime_dark_m29)s, %(elg_efftime_dark_m29)s, %(bgs_efftime_bright_m29)s, %(lya_efftime_dark_m29)s, %(gpb_efftime_dark_m29)s, %(gpb_efftime_bright_m29)s, %(gpb_efftime_backup_m29)s, %(transparency_gfa_m29)s, %(seeing_gfa_m29)s, %(fiber_fracflux_gfa_m29)s, %(fiber_fracflux_elg_gfa_m29)s, %(fiber_fracflux_bgs_gfa_m29)s, %(fiberfac_gfa_m29)s, %(fiberfac_elg_gfa_m29)s, %(fiberfac_bgs_gfa_m29)s, %(airmass_gfa_m29)s, %(sky_mag_ab_gfa_m29)s, %(sky_mag_g_spec_m29)s, %(sky_mag_r_spec_m29)s, %(sky_mag_z_spec_m29)s, %(efftime_gfa_m29)s, %(efftime_dark_gfa_m29)s, %(efftime_bright_gfa_m29)s, %(efftime_backup_gfa_m29)s), (%(night_m30)s, %(expid_m30)s, %(tileid_m30)s, %(tilera_m30)s, %(tiledec_m30)s, %(date_obs_m30)s, %(mjd_m30)s, %(survey_m30)s, %(program_m30)s, %(faprgrm_m30)s, %(faflavor_m30)s, %(exptime_m30)s, %(efftime_spec_m30)s, %(goaltime_m30)s, %(goaltype_m30)s, %(mintfrac_m30)s, %(airmass_m30)s, %(ebv_m30)s, %(seeing_etc_m30)s, %(efftime_etc_m30)s, %(tsnr2_elg_m30)s, %(tsnr2_qso_m30)s, %(tsnr2_lrg_m30)s, %(tsnr2_lya_m30)s, %(tsnr2_bgs_m30)s, %(tsnr2_gpbdark_m30)s, %(tsnr2_gpbbright_m30)s, %(tsnr2_gpbbackup_m30)s, %(lrg_efftime_dark_m30)s, %(elg_efftime_dark_m30)s, %(bgs_efftime_bright_m30)s, %(lya_efftime_dark_m30)s, %(gpb_efftime_dark_m30)s, %(gpb_efftime_bright_m30)s, %(gpb_efftime_backup_m30)s, %(transparency_gfa_m30)s, %(seeing_gfa_m30)s, %(fiber_fracflux_gfa_m30)s, %(fiber_fracflux_elg_gfa_m30)s, %(fiber_fracflux_bgs_gfa_m30)s, %(fiberfac_gfa_m30)s, %(fiberfac_elg_gfa_m30)s, %(fiberfac_bgs_gfa_m30)s, %(airmass_gfa_m30)s, %(sky_mag_ab_gfa_m30)s, %(sky_mag_g_spec_m30)s, %(sky_mag_r_spec_m30)s, %(sky_mag_z_spec_m30)s, %(efftime_gfa_m30)s, %(efftime_dark_gfa_m30)s, %(efftime_bright_gfa_m30)s, %(efftime_backup_gfa_m30)s) ON CONFLICT (expid) DO UPDATE SET night = excluded.night, tileid = excluded.tileid, tilera = excluded.tilera, tiledec = excluded.tiledec, date_obs = excluded.date_obs, mjd = excluded.mjd, survey = excluded.survey, program = excluded.program, faprgrm = excluded.faprgrm, faflavor = excluded.faflavor, exptime = excluded.exptime, efftime_spec = excluded.efftime_spec, goaltime = excluded.goaltime, goaltype = excluded.goaltype, mintfrac = excluded.mintfrac, airmass = excluded.airmass, ebv = excluded.ebv, seeing_etc = excluded.seeing_etc, efftime_etc = excluded.efftime_etc, tsnr2_elg = excluded.tsnr2_elg, tsnr2_qso = excluded.tsnr2_qso, tsnr2_lrg = excluded.tsnr2_lrg, tsnr2_lya = excluded.tsnr2_lya, tsnr2_bgs = excluded.tsnr2_bgs, tsnr2_gpbdark = excluded.tsnr2_gpbdark, tsnr2_gpbbright = excluded.tsnr2_gpbbright, tsnr2_gpbbackup = excluded.tsnr2_gpbbackup, lrg_efftime_dark = excluded.lrg_efftime_dark, elg_efftime_dark = excluded.elg_efftime_dark, bgs_efftime_bright = excluded.bgs_efftime_bright, lya_efftime_dark = excluded.lya_efftime_dark, gpb_efftime_dark = excluded.gpb_efftime_dark, gpb_efftime_bright = excluded.gpb_efftime_bright, gpb_efftime_backup = excluded.gpb_efftime_backup, transparency_gfa = excluded.transparency_gfa, seeing_gfa = excluded.seeing_gfa, fiber_fracflux_gfa = excluded.fiber_fracflux_gfa, fiber_fracflux_elg_gfa = excluded.fiber_fracflux_elg_gfa, fiber_fracflux_bgs_gfa = excluded.fiber_fracflux_bgs_gfa, fiberfac_gfa = excluded.fiberfac_gfa, fiberfac_elg_gfa = excluded.fiberfac_elg_gfa, fiberfac_bgs_gfa = excluded.fiberfac_bgs_gfa, airmass_gfa = excluded.airmass_gfa, sky_mag_ab_gfa = excluded.sky_mag_ab_gfa, sky_mag_g_spec = excluded.sky_mag_g_spec, sky_mag_r_spec = excluded.sky_mag_r_spec, sky_mag_z_spec = excluded.sky_mag_z_spec, efftime_gfa = excluded.efftime_gfa, efftime_dark_gfa = excluded.efftime_dark_gfa, efftime_bright_gfa = excluded.efftime_bright_gfa, efftime_backup_gfa = excluded.efftime_backup_gfa\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "stmt = db.upsert(load_exposures)\n",
+    "# stmt = db.upsert(load_exposures)\n",
     "# print(stmt)\n",
-    "db.dbSession.execute(stmt)\n",
-    "db.dbSession.commit()"
+    "# db.dbSession.execute(stmt)\n",
+    "# db.dbSession.commit()\n",
+    "db.dbSession.rollback()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": null,
    "id": "7974d98d-dd93-492c-9cad-dcf0085a4b92",
    "metadata": {
     "tags": []
@@ -752,8 +493,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "bff92e7d-2627-45bf-a739-c2b30a059aee",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "load_tiles[12345]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "f419c90d-1f45-46e4-add8-db81ed260a83",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "tile_index = 0"
@@ -763,10 +518,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "605895fe",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "load_tiles = db.dbSession.query(db.Tile).filter(db.Tile.tileid == tile_id).all()"
+    "load_tiles = db.dbSession.query(db.Tile).filter(db.Tile.tileid == 26055).all()\n",
+    "load_tiles"
    ]
   },
   {
@@ -826,7 +584,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "94e10407-edee-4731-ad7c-3de63749dd7f",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -1012,7 +772,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": null,
    "id": "b5db94c2-d3f4-41ab-a05a-f24c91f202b6",
    "metadata": {
     "tags": []

--- a/doc/nb/TestNewTile.ipynb
+++ b/doc/nb/TestNewTile.ipynb
@@ -654,7 +654,7 @@
    ],
    "source": [
     "load_tiles = list()\n",
-    "load_exposures = list() \n",
+    "load_exposures = list()\n",
     "for new_tile in (load_new_tiles + load_updated_tiles):\n",
     "    row_index = np.where((update_exposures_table['TILEID'] == new_tile.tileid) & (update_exposures_table['EFFTIME_SPEC'] > 0))[0]\n",
     "    if len(row_index) > 0:\n",
@@ -664,8 +664,8 @@
     "        print(\"ERROR: No valid exposures found for tile {0:d}, even though EFFTIME_SPEC == {1:f}!\".format(new_tile.tileid, new_tile.efftime_spec))\n",
     "        bad_index = np.where((update_exposures_table['TILEID'] == new_tile.tileid))[0]\n",
     "        print(update_exposures_table[['EXPID', 'NIGHT', 'MJD', 'EFFTIME_SPEC']][bad_index])\n",
-    "        bad_tiles.append(new_tile)\n",
-    "load_tiles, load_exposures"
+    "        # bad_tiles.append(new_tile)\n",
+    "# load_tiles, load_exposures"
    ]
   },
   {
@@ -686,44 +686,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
-   "id": "5104bb5d-2706-4f51-ad72-2c5989a95424",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "from sqlalchemy.dialects.postgresql import insert"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 74,
-   "id": "1f09208d-8c25-4758-9e15-24f69166f76e",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INSERT INTO daily.version (id, package, version) VALUES (%(id_m0)s, %(package_m0)s, %(version_m0)s), (%(id_m1)s, %(package_m1)s, %(version_m1)s), (%(id_m2)s, %(package_m2)s, %(version_m2)s) ON CONFLICT (id) DO UPDATE SET package = excluded.package, version = excluded.version\n"
-     ]
-    }
-   ],
-   "source": [
-    "stmt = insert(db.Version).values([{'id': 11, 'package': 'foo', 'version': '1.2.6'}, {'id': 10, 'package': 'tiles', 'version': 'main.test6'}, {'id': 12, 'package': 'bar', 'version': '3.4.5'}])\n",
-    "# stmt = stmt.on_conflict_do_update(index_elements=[db.Version.id], set_=dict(package=getattr(stmt.excluded, 'package'), version=getattr(stmt.excluded, 'version')))\n",
-    "stmt = stmt.on_conflict_do_update(index_elements=[db.Version.id], set_=dict([(c, getattr(stmt.excluded, c.name)) for c in db.Version.__table__.columns if c.name != 'id']))\n",
-    "print(stmt)\n",
-    "# db.dbSession.rollback()\n",
-    "db.dbSession.execute(stmt)\n",
-    "db.dbSession.commit()"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 76,
    "id": "1f0d8062-740f-46a4-8eb0-fc93cb4b5c35",
    "metadata": {
@@ -731,63 +693,10 @@
    },
    "outputs": [],
    "source": [
-    "load_tiles_as_dict = list()\n",
-    "for t in load_tiles:\n",
-    "    tt = t.__dict__.copy()\n",
-    "    del tt['_sa_instance_state']\n",
-    "    load_tiles_as_dict.append(tt)\n",
-    "stmt = insert(db.Tile).values(load_tiles_as_dict)\n",
-    "stmt = stmt.on_conflict_do_update(index_elements=[db.Tile.tileid], set_=dict([(c, getattr(stmt.excluded, c.name)) for c in db.Tile.__table__.columns if c.name != 'tileid']))\n",
+    "stmt = db.upsert(load_tiles)\n",
+    "# print(stmt)\n",
     "db.dbSession.execute(stmt)\n",
     "db.dbSession.commit()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 85,
-   "id": "32163199-fec8-4e03-bf18-9fc21c68e6f8",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(<sqlalchemy.orm.attributes.InstrumentedAttribute at 0x7f9bda1a6520>,\n",
-       " Column('expid', Integer(), table=<exposure>, primary_key=True, nullable=False))"
-      ]
-     },
-     "execution_count": 85,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "getattr(load_exposures[0].__class__, 'expid'), [c for c in load_exposures[0].__class__.__table__.columns if c.primary_key][0]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 88,
-   "id": "56a310b4-fb2e-4a40-88ed-2b9609379422",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "def upsert(rows):\n",
-    "    \"\"\"Convert a list of ORM objects into an 'UPSERT' statement.\n",
-    "    \"\"\"\n",
-    "    cls = rows[0].__class__\n",
-    "    pk = [c for c in cls.__table__.columns if c.primary_key][0]\n",
-    "    inserts = list()\n",
-    "    for row in rows:\n",
-    "        rr = row.__dict__.copy()\n",
-    "        del rr['_sa_instance_state']\n",
-    "        inserts.append(rr)\n",
-    "    stmt = insert(cls).values(inserts)\n",
-    "    stmt = stmt.on_conflict_do_update(index_elements=[getattr(cls, pk.name)], set_=dict([(c, getattr(stmt.excluded, c.name)) for c in cls.__table__.columns if c.name != pk.name]))\n",
-    "    return stmt"
    ]
   },
   {
@@ -807,8 +716,8 @@
     }
    ],
    "source": [
-    "stmt = upsert(load_exposures)\n",
-    "print(stmt)\n",
+    "stmt = db.upsert(load_exposures)\n",
+    "# print(stmt)\n",
     "db.dbSession.execute(stmt)\n",
     "db.dbSession.commit()"
    ]
@@ -822,8 +731,7 @@
    },
    "outputs": [],
    "source": [
-    "stmt = upsert(load_frames)\n",
-    "# db.dbSession.rollback()\n",
+    "stmt = db.upsert(load_frames)\n",
     "# print(stmt)\n",
     "db.dbSession.execute(stmt)\n",
     "db.dbSession.commit()"

--- a/py/specprodDB/data/load_specprod_db.ini
+++ b/py/specprodDB/data/load_specprod_db.ini
@@ -64,7 +64,7 @@ tiles = 2.0
 
 [kibo]
 release = dr2
-photometry = v1.0
+photometry = v1.1
 target_summary = false
 redshift = patch/v1
 tiles = 2.0

--- a/py/specprodDB/data/load_specprod_db.ini
+++ b/py/specprodDB/data/load_specprod_db.ini
@@ -7,7 +7,8 @@
 # This is intended to configure (meta)data releated to the load process itself.
 #
 username = desi_admin
-hostname = specprod-db.desi.lbl.gov
+# hostname = specprod-db.desi.lbl.gov
+hostname = db2-loadbalancer.specprod.production.svc.spin.nersc.org
 chunksize = 50000
 
 [fuji]

--- a/py/specprodDB/data/load_specprod_db.ini
+++ b/py/specprodDB/data/load_specprod_db.ini
@@ -69,6 +69,13 @@ target_summary = false
 redshift = patch/v1
 tiles = 2.0
 
+[loa]
+release = dr2
+photometry = v1.0
+target_summary = false
+redshift = patch/v1
+tiles = 2.0
+
 [daily]
 release = daily
 photometry = computed

--- a/py/specprodDB/data/load_specprod_db.ini
+++ b/py/specprodDB/data/load_specprod_db.ini
@@ -66,7 +66,7 @@ tiles = 2.0
 release = dr2
 photometry = v1.1
 target_summary = false
-redshift = patch/v1
+redshift = patch/v1.1
 tiles = 2.0
 
 [loa]

--- a/py/specprodDB/data/load_specprod_db.ini
+++ b/py/specprodDB/data/load_specprod_db.ini
@@ -63,7 +63,7 @@ tiles = 2.0
 
 [kibo]
 release = dr2
-photometry = v1.2
+photometry = v1.0
 target_summary = false
 redshift = patch/v1
 tiles = 2.0

--- a/py/specprodDB/load.py
+++ b/py/specprodDB/load.py
@@ -1445,7 +1445,7 @@ def load_file(filepaths, tcls, hdu=1, row_filter=None, q3c=None, chunksize=50000
                 dbSession.add_all(data_chunk)
                 dbSession.commit()
                 log.info("Inserted %d rows in %s.",
-                        min((k+1)*chunksize, finalrows), tn)
+                         min((k+1)*chunksize, finalrows), tn)
             else:
                 log.error("Detected empty data chunk in %s!", tn)
     if q3c is not None:

--- a/py/specprodDB/load.py
+++ b/py/specprodDB/load.py
@@ -1420,7 +1420,11 @@ def load_file(filepaths, tcls, hdu=1, row_filter=None, q3c=None, chunksize=50000
             data_chunk = orm_objects[k*chunksize:(k+1)*chunksize]
             if len(data_chunk) > 0:
                 loaded_rows += len(data_chunk)
-                dbSession.add_all(data_chunk)
+                if tn == 'photometry' and os.path.basename(filepath).startswith('targetphot'):
+                    statement = upsert(data_chunk, do_nothing=True)
+                    dbSession.execute(statement)
+                else:
+                    dbSession.add_all(data_chunk)
                 dbSession.commit()
                 log.info("Inserted %d rows in %s.",
                          min((k+1)*chunksize, finalrows), tn)
@@ -1721,7 +1725,7 @@ def main():
                'targetphot': [{'filepaths': target_files,
                                'tcls': Photometry,
                                'hdu': 'TARGETPHOT',
-                               'row_filter': deduplicate_targetid,
+                               # 'row_filter': deduplicate_targetid,
                                'q3c': 'ra',
                                'chunksize': chunksize
                                }],

--- a/py/specprodDB/load.py
+++ b/py/specprodDB/load.py
@@ -1674,7 +1674,8 @@ def main():
     if target_summary:
         target_files = os.path.join(options.datapath, 'vac', release, 'lsdr9-photometry', specprod, photometry_version, 'potential-targets', f'targetphot-potential-{specprod}.fits')
     else:
-        target_files = glob.glob(os.path.join(options.datapath, 'vac', release, 'lsdr9-photometry', specprod, photometry_version, 'potential-targets', f'targetphot-potential-*-{specprod}.fits'))
+        # target_files = glob.glob(os.path.join(options.datapath, 'vac', release, 'lsdr9-photometry', specprod, photometry_version, 'potential-targets', f'targetphot-potential-*-{specprod}.fits'))
+        target_files = glob.glob(os.path.join(options.datapath, 'vac', release, 'lsdr9-photometry', specprod, photometry_version, 'potential-targets', f'targetphot-potential-*.fits'))
     if redshift_type == 'base' or redshift_type == 'patch':
         redshift_dir = os.path.join(options.datapath, 'spectro', 'redux', specprod, 'zcatalog')
         if redshift_type == 'base':

--- a/py/specprodDB/load.py
+++ b/py/specprodDB/load.py
@@ -1375,7 +1375,7 @@ def load_file(filepaths, tcls, hdu=1, row_filter=None, q3c=None, chunksize=50000
             log.info("Row filter removed all data rows, skipping %s.", filepath)
             continue
         log.info("Row filter applied on %s; %d rows remain.", tn, good_rows.sum())
-        orm_objects = tcls.convert(data, row_filter=good_rows)
+        orm_objects = tcls.convert(data, row_index=good_rows)
         log.info("Converted data to ORM objects on %s.", tn)
         del data
         finalrows = len(orm_objects)

--- a/py/specprodDB/load.py
+++ b/py/specprodDB/load.py
@@ -1420,11 +1420,7 @@ def load_file(filepaths, tcls, hdu=1, row_filter=None, q3c=None, chunksize=50000
             data_chunk = orm_objects[k*chunksize:(k+1)*chunksize]
             if len(data_chunk) > 0:
                 loaded_rows += len(data_chunk)
-                if tn == 'photometry' and os.path.basename(filepath).startswith('targetphot'):
-                    statement = upsert(data_chunk, do_nothing=True)
-                    dbSession.execute(statement)
-                else:
-                    dbSession.add_all(data_chunk)
+                dbSession.add_all(data_chunk)
                 dbSession.commit()
                 log.info("Inserted %d rows in %s.",
                          min((k+1)*chunksize, finalrows), tn)
@@ -1725,7 +1721,7 @@ def main():
                'targetphot': [{'filepaths': target_files,
                                'tcls': Photometry,
                                'hdu': 'TARGETPHOT',
-                               # 'row_filter': deduplicate_targetid,
+                               'row_filter': deduplicate_targetid,
                                'q3c': 'ra',
                                'chunksize': chunksize
                                }],

--- a/py/specprodDB/load.py
+++ b/py/specprodDB/load.py
@@ -1228,7 +1228,10 @@ class Ztile(SchemaMixin, Base):
         data_columns = list()
         for column in cls.__table__.columns:
             if column.name == 'id':
-                id0 = spgrpid(spgrp) << 27 | data['SPGRPVAL'][row_index].base.astype(np.int64)
+                if 'survey' in default_columns:
+                    id0 = ((spgrpid(spgrp) << 27 | data['SPGRPVAL'][row_index].base.astype(np.int64)) << 32) | tileid
+                else:
+                    id0 = ((spgrpid(spgrp) << 27 | data['SPGRPVAL'][row_index].base.astype(np.int64)) << 32) | data['TILEID'][row_index].astype(np.int64)
                 data_column = [(i0 << 64) | i1 for i0, i1 in zip(id0.tolist(), data['TARGETID'][row_index].tolist())]
             elif column.name == 'targetphotid':
                 if 'survey' in default_columns:

--- a/py/specprodDB/load.py
+++ b/py/specprodDB/load.py
@@ -1383,7 +1383,7 @@ def load_file(filepaths, tcls, hdu=1, row_filter=None, q3c=None, chunksize=50000
         Read a data table from this HDU (default 1).
     row_filter : callable, optional
         If set, apply this filter to the rows to be loaded.  The function
-        should return :class:`bool`, with ``True`` meaning a good row.
+        should return an array of indexes of "good" rows.
     q3c : :class:`str`, optional
         If set, create q3c index on the table, using the RA column
         named `q3c`.
@@ -1414,13 +1414,13 @@ def load_file(filepaths, tcls, hdu=1, row_filter=None, q3c=None, chunksize=50000
             log.error("Unrecognized data file, %s!", filepath)
             return
         if row_filter is None:
-            good_rows = np.ones((len(data),), dtype=bool)
+            good_rows = np.arange(len(data))
         else:
             good_rows = row_filter(data)
-        if good_rows.sum() == 0:
+        if len(good_rows) == 0:
             log.info("Row filter removed all data rows, skipping %s.", filepath)
             continue
-        log.info("Row filter applied on %s; %d rows remain.", tn, good_rows.sum())
+        log.info("Row filter applied on %s; %d rows remain.", tn, len(good_rows))
         orm_objects = tcls.convert(data, row_index=good_rows)
         log.info("Converted data to ORM objects on %s.", tn)
         del data

--- a/py/specprodDB/load.py
+++ b/py/specprodDB/load.py
@@ -1676,14 +1676,22 @@ def main():
     else:
         # target_files = glob.glob(os.path.join(options.datapath, 'vac', release, 'lsdr9-photometry', specprod, photometry_version, 'potential-targets', f'targetphot-potential-*-{specprod}.fits'))
         target_files = glob.glob(os.path.join(options.datapath, 'vac', release, 'lsdr9-photometry', specprod, photometry_version, 'potential-targets', f'targetphot-potential-*.fits'))
+    generate_primary = False
     if redshift_type == 'base' or redshift_type == 'patch':
-        redshift_dir = os.path.join(options.datapath, 'spectro', 'redux', specprod, 'zcatalog')
         if redshift_type == 'base':
-            zpix_file = os.path.join(redshift_dir, f'zall-pix-{specprod}.fits')
-            ztile_file = os.path.join(redshift_dir, f'zall-tilecumulative-{specprod}.fits')
+            redshift_dir = os.path.join(options.datapath, 'spectro', 'redux', specprod, 'zcatalog')
         else:
-            zpix_file = os.path.join(redshift_dir, redshift_version, f'zall-pix-{specprod}.fits')
-            ztile_file = os.path.join(redshift_dir, redshift_version, f'zall-tilecumulative-{specprod}.fits')
+            redshift_dir = os.path.join(options.datapath, 'spectro', 'redux', specprod, 'zcatalog', redshift_version)
+        zpix_file = os.path.join(redshift_dir, f'zall-pix-{specprod}.fits')
+        ztile_file = os.path.join(redshift_dir, f'zall-tilecumulative-{specprod}.fits')
+        if not os.path.exists(zpix_file):
+            log.warning("%s not found, will use individual survey-program files.")
+            zpix_file = glob.glob(os.path.join(redshift_dir, f'zpix-*.fits'))
+            generate_primary = True
+        if not os.path.exists(ztile_file):
+            log.warning("%s not found, will use individual survey-program files.")
+            ztile_file = glob.glob(os.path.join(redshift_dir, f'ztile-*-cumulative.fits'))
+            generate_primary = True
     elif redshift_type == 'zcat':
         redshift_dir = os.path.join(options.datapath, 'vac', release, 'zcat', specprod)
         zpix_file = os.path.join(redshift_dir, redshift_version, f'zall-pix-{release}-vac.fits')
@@ -1817,6 +1825,8 @@ def main():
             log.info("Finished loading %s.", tn)
     if options.load == 'fiberassign':
         log.info("Consider running VACUUM FULL VERBOSE ANALYZE at this point.")
+    if options.load == 'redshift' and generate_primary:
+        log.info("Generating global primary columns.")
     #
     # Clean up.
     #

--- a/py/specprodDB/tile.py
+++ b/py/specprodDB/tile.py
@@ -73,8 +73,10 @@ def potential_targets(tileid):
         A table containing potential target information.
     """
     potential_targets_table = Table.read(fiberassign_file(tileid), format='fits', hdu='TARGETS')
+    db.log.debug("Found %d potential targets.", len(potential_targets_table))
     no_sky_rows = no_sky(potential_targets_table)
     potential_targets_table = Table(potential_targets_table[no_sky_rows])
+    db.log.debug("%d potential targets remain after removing sky targets.", len(potential_targets_table))
     return potential_targets_table
 
 
@@ -96,6 +98,7 @@ def potential_photometry(tile, targets):
     :class:`~astropy.table.Table`
         A Table that will be the input to photometric search functions.
     """
+    db.log.debug("Checking for existing photometry.")
     potential_tractorphot_already_loaded = db.dbSession.query(db.Photometry.targetid).filter(db.Photometry.targetid.in_(targets['TARGETID'].tolist())).all()
     potential_tractorphot_not_already_loaded = np.ones((len(targets),), dtype=bool)
     if len(potential_tractorphot_already_loaded) > 0:
@@ -126,7 +129,9 @@ def targetphot(catalog):
     :class:`~astropy.table.Table`
         A Table containing the targeting data.
     """
+    db.log.debug("Starting gather_targetphot(); %d objects in input catalog.", len(catalog))
     potential_targetphot = gather_targetphot(catalog, racolumn='TARGET_RA', deccolumn='TARGET_DEC')
+    db.log.debug("Finished with gather_targetphot(); %d objects found.", len(potential_targetphot))
     potential_targetphot['SURVEY'] = catalog['SURVEY']
     potential_targetphot['PROGRAM'] = catalog['PROGRAM']
     potential_targetphot['TILEID'] = catalog['TILEID']
@@ -151,7 +156,9 @@ def tractorphot(catalog):
     :class:`~astropy.table.Table`
         A Table containing the photometry data.
     """
+    db.log.debug("Starting gather_tractorphot(); %d objects in input catalog.", len(catalog))
     potential_tractorphot = gather_tractorphot(catalog, racolumn='TARGET_RA', deccolumn='TARGET_DEC')
+    db.log.debug("Finished with gather_tractorphot(); %d objects found.", len(potential_tractorphot))
     assert (np.where(potential_tractorphot['RELEASE'] == 0)[0] == np.where(potential_tractorphot['BRICKNAME'] == '')[0]).all()
     return potential_tractorphot
 

--- a/py/specprodDB/tile.py
+++ b/py/specprodDB/tile.py
@@ -322,7 +322,9 @@ def load_redshift(tile, spgrp='cumulative'):
                                        tile.tileid, firstnight,
                                        row_index=row_index)
     if len(load_ztile) > 0:
-        db.dbSession.add_all(load_ztile)
+        statement = db.upsert(load_ztile)
+        db.dbSession.execute(statement)
+        # db.dbSession.add_all(load_ztile)
         db.dbSession.commit()
         db.log.info("Loaded %d rows of Ztile data.", len(load_ztile))
     else:
@@ -436,6 +438,8 @@ def get_options(description="Load data for one tile into a specprod database."):
                       help='Update primary redshift values and indexes for all tiles.')
     prsr.add_argument('-t', '--tiles-file', action='store', dest='tiles_file', metavar='FILE',
                       help='Override the top-level tiles file associated with a specprod.')
+    prsr.add_argument('-u', '--update', action='store_true', dest='update',
+                      help='Specify that this is an update to an already-loaded tile.')
     prsr.add_argument('tile', metavar='TILEID', type=int, help='Load TILEID.')
     options = prsr.parse_args()
     return options
@@ -509,10 +513,10 @@ def main():
     # Find the tile in the top-level tiles file.
     #
     if options.tiles_file is None:
-        tiles_file = findfile('tiles', readonly=True).replace('.fits', '.csv')
+        tiles_file = findfile('tiles', readonly=True)
     else:
         tiles_file = options.tiles_file
-    tiles_table = Table.read(tiles_file, format='ascii.csv')
+    tiles_table = Table.read(tiles_file, format='fits', hdu='TILES')
     row_index = np.where(tiles_table['TILEID'] == options.tile)[0]
     if len(row_index) == 1:
         candidate_tiles = db.Tile.convert(tiles_table, row_index=row_index)
@@ -546,7 +550,9 @@ def main():
         assert len(row_index) > 0
         load_frames += db.Frame.convert(frames_table, row_index=row_index)
     try:
-        db.dbSession.add_all(candidate_tiles)
+        statement = db.upsert(candidate_tiles)
+        db.dbSession.execute(statement)
+        # db.dbSession.add_all(candidate_tiles)
         db.dbSession.commit()
     except IntegrityError as exc:
         #
@@ -557,40 +563,45 @@ def main():
         db.log.critical("Message was: %s", exc.args[0])
         db.dbSession.rollback()
         return 1
+    new_tile = candidate_tiles[0]
     try:
-        db.dbSession.add_all(load_exposures)
+        statement = db.upsert(load_exposures)
+        db.dbSession.execute(statement)
+        # db.dbSession.add_all(load_exposures)
         db.dbSession.commit()
     except IntegrityError as exc:
-        db.log.critical("Exposures for tile %d cannot be loaded!", candidate_tiles[0].tileid)
+        db.log.critical("Exposures for tile %d cannot be loaded!", new_tile.tileid)
         db.log.critical("Message was: %s", exc.args[0])
         db.dbSession.rollback()
-        db.dbSession.delete(candidate_tiles[0])
+        db.dbSession.delete(new_tile)
         db.dbSession.commit()
         return 1
-    db.dbSession.add_all(load_frames)
+    statement = db.upsert(load_frames)
+    db.dbSession.execute(statement)
+    # db.dbSession.add_all(load_frames)
     db.dbSession.commit()
     #
-    # Load photometry.
+    # Load photometry. If this is an update, these should already be loaded.
     #
-    new_tile = candidate_tiles[0]
-    potential_targets_table = potential_targets(new_tile.tileid)
-    potential_cat = potential_photometry(new_tile, potential_targets_table)
-    potential_targetphot = targetphot(potential_cat)
-    potential_tractorphot = tractorphot(potential_cat)
-    loaded_photometry = load_photometry(potential_tractorphot)
-    loaded_targetphot = load_targetphot(potential_targetphot, loaded_photometry)
-    #
-    # Load targeting table.
-    #
-    loaded_target = load_target(new_tile, potential_targetphot)
+    if not options.update:
+        potential_targets_table = potential_targets(new_tile.tileid)
+        potential_cat = potential_photometry(new_tile, potential_targets_table)
+        potential_targetphot = targetphot(potential_cat)
+        potential_tractorphot = tractorphot(potential_cat)
+        loaded_photometry = load_photometry(potential_tractorphot)
+        loaded_targetphot = load_targetphot(potential_targetphot, loaded_photometry)
+        #
+        # Load targeting table.
+        #
+        loaded_target = load_target(new_tile, potential_targetphot)
+        #
+        # Load fiberassign and potential.
+        #
+        loaded_fiberassign, loaded_potential = load_fiberassign(new_tile)
     #
     # Load tile/cumulative redshifts.
     #
     loaded_ztile = load_redshift(new_tile)
-    #
-    # Load fiberassign and potential.
-    #
-    loaded_fiberassign, loaded_potential = load_fiberassign(new_tile)
     #
     # Update global values, if requested.
     #
@@ -600,4 +611,6 @@ def main():
     #
     # Clean up.
     #
+    db.dbSession.close()
+    db.engine.dispose()
     return 0


### PR DESCRIPTION
This PR comprises the code changes needed to load the `kibo`/`loa` database schema.

Note that the branch name `tile-based-updates` has drifted away from the actual work done on this branch, although there is some support for daily, tile-based loading added.